### PR TITLE
Refactor model and client method signatures

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,33 @@
 {
   "pins" : [
     {
+      "identity" : "base58",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/anquii/Base58.git",
+      "state" : {
+        "revision" : "7e4a1e4e6813c750ed2f9e80a0494c608eebb2ca",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "base58check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/anquii/Base58Check.git",
+      "state" : {
+        "revision" : "f35a770ff7f3fd553cc44057f492c0107cc7b481",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+        "version" : "5.3.0"
+      }
+    },
+    {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,16 @@ let package = Package(
                     targets: ["ConcordiumSwiftSDK"]),
         ],
         dependencies: [
-            .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.15.0")
+            .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.15.0"),
+            .package(url: "https://github.com/anquii/Base58Check.git", from: "1.0.0"),
         ],
         targets: [
             .target(
                     name: "ConcordiumSwiftSDK",
-                    dependencies: [.product(name: "GRPC", package: "grpc-swift")]
+                    dependencies: [
+                        .product(name: "GRPC", package: "grpc-swift"),
+                        "Base58Check",
+                    ]
             ),
             .testTarget(
                     name: "ConcordiumSwiftSDKTests",

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
         name: "ConcordiumSwiftSDK",
         platforms: [
+            .macOS(.v10_15),
             .iOS(.v15),
         ],
         products: [

--- a/Sources/ConcordiumSwiftSDK/Client.swift
+++ b/Sources/ConcordiumSwiftSDK/Client.swift
@@ -12,7 +12,7 @@ class Client {
     }
 
     func getCryptographicParameters(at block: BlockIdentifier) async throws -> CryptographicParameters {
-        var req = block.toGrpcType()
+        let req = block.toGrpcType()
         let res = try await grpc.getCryptographicParameters(req).response.get()
         return CryptographicParameters(
                 onChainCommitmentKey: res.onChainCommitmentKey.hexadecimalString(),
@@ -23,7 +23,7 @@ class Client {
 
     func getNextAccountSequenceNumber(of address: AccountAddress) async throws -> NextAccountSequenceNumber {
         var req = Concordium_V2_AccountAddress()
-        req.value = address
+        req.value = address.bytes
         let res = try await grpc.getNextAccountSequenceNumber(req).response.get()
         return NextAccountSequenceNumber(
                 sequenceNumber: res.sequenceNumber.value,

--- a/Sources/ConcordiumSwiftSDK/Client.swift
+++ b/Sources/ConcordiumSwiftSDK/Client.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 import GRPC
-import NIOPosix
 import NIOCore
+import NIOPosix
 
 class Client {
     let grpc: Concordium_V2_QueriesNIOClient
@@ -11,38 +11,23 @@ class Client {
         grpc = Concordium_V2_QueriesNIOClient(channel: channel)
     }
 
-    private func getBlockHashInput(blockHash: BlockHash?) -> Concordium_V2_BlockHashInput {
-        if let blockHash {
-            var h = Concordium_V2_BlockHash()
-            h.value = blockHash
-            var b = Concordium_V2_BlockHashInput()
-            b.given = h
-            return b
-        } else {
-            var b = Concordium_V2_BlockHashInput()
-            b.lastFinal = Concordium_V2_Empty()
-            return b
-        }
+    func getCryptographicParameters(at block: BlockIdentifier) async throws -> CryptographicParameters {
+        var req = block.toGrpcType()
+        let res = try await grpc.getCryptographicParameters(req).response.get()
+        return CryptographicParameters(
+                onChainCommitmentKey: res.onChainCommitmentKey.hexadecimalString(),
+                bulletproofGenerators: res.bulletproofGenerators.hexadecimalString(),
+                genesisString: res.genesisString
+        )
     }
 
-    func getCryptographicParameters(at block: BlockIdentifier) async -> EventLoopFuture<CryptographicParameters> {
-        return grpc
-                .getCryptographicParameters(block.toGrpcType())
-                .response
-                .map({ v in
-                    CryptographicParameters(
-                            onChainCommitmentKey: v.onChainCommitmentKey.hexadecimalString(),
-                            bulletproofGenerators: v.bulletproofGenerators.hexadecimalString(),
-                            genesisString: v.genesisString
-                    )
-                })
-    }
-
-    func getNextAccountSequenceNumber(forAddress address: AccountAddress) -> EventLoopFuture<NextAccountSequenceNumber?> {
-        var grpcAddress = Concordium_V2_AccountAddress()
-        grpcAddress.value = address
-        return grpc.getNextAccountSequenceNumber(grpcAddress).response.map({ res in
-            NextAccountSequenceNumber(sequenceNumber: res.sequenceNumber.value, allFinal: res.allFinal)
-        })
+    func getNextAccountSequenceNumber(of address: AccountAddress) async throws -> NextAccountSequenceNumber {
+        var req = Concordium_V2_AccountAddress()
+        req.value = address
+        let res = try await grpc.getNextAccountSequenceNumber(req).response.get()
+        return NextAccountSequenceNumber(
+                sequenceNumber: res.sequenceNumber.value,
+                allFinal: res.allFinal
+        )
     }
 }

--- a/Sources/ConcordiumSwiftSDK/Model/Account.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Account.swift
@@ -1,9 +1,27 @@
 import Foundation
+import Base58Check
 
-typealias AccountAddress = Data // 32 bytes
+fileprivate let accountAddressBase58CheckVersion: UInt8 = 1
+
+struct AccountAddress {
+    let bytes: Data // 32 bytes (Base58Check without version byte)
+    
+    init(base58Check: String) throws {
+        let bytes = try Base58Check().decode(string: base58Check)
+        let v = bytes[0]
+        if v != accountAddressBase58CheckVersion {
+            throw GrpcError.unexpectedBase64CheckVersionByte(expected: accountAddressBase58CheckVersion, actual: v)
+        }
+        self.bytes = bytes[1...] // exclude initial version byte
+    }
+}
 typealias SequenceNumber = UInt64
 
 struct NextAccountSequenceNumber {
     let sequenceNumber: SequenceNumber
     let allFinal: Bool
+}
+
+extension AccountAddress {
+
 }

--- a/Sources/ConcordiumSwiftSDK/Model/Account.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Account.swift
@@ -1,16 +1,17 @@
 import Foundation
 import Base58Check
 
-fileprivate let accountAddressBase58CheckVersion: UInt8 = 1
+fileprivate let accountAddressBase58CheckVersionByte: UInt8 = 1
 
 struct AccountAddress {
-    let bytes: Data // 32 bytes (Base58Check without version byte)
+    let bytes: Data // 32 bytes
     
+    /// Construct address from the standard representation (Base58Check).
     init(base58Check: String) throws {
         let bytes = try Base58Check().decode(string: base58Check)
-        let v = bytes[0]
-        if v != accountAddressBase58CheckVersion {
-            throw GrpcError.unexpectedBase64CheckVersionByte(expected: accountAddressBase58CheckVersion, actual: v)
+        let versionByte = bytes[0]
+        if versionByte != accountAddressBase58CheckVersionByte {
+            throw GrpcError.unexpectedBase64CheckVersionByte(expected: accountAddressBase58CheckVersionByte, actual: versionByte)
         }
         self.bytes = bytes[1...] // exclude initial version byte
     }

--- a/Sources/ConcordiumSwiftSDK/Model/Account.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Account.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+typealias AccountAddress = Data // 32 bytes
+typealias SequenceNumber = UInt64
+
+struct NextAccountSequenceNumber {
+    let sequenceNumber: SequenceNumber
+    let allFinal: Bool
+}

--- a/Sources/ConcordiumSwiftSDK/Model/Account.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Account.swift
@@ -1,19 +1,19 @@
 import Foundation
 import Base58Check
 
-fileprivate let accountAddressBase58CheckVersionByte: UInt8 = 1
+fileprivate let accountAddressBase58CheckVersion: UInt8 = 1
 
 struct AccountAddress {
     let bytes: Data // 32 bytes
     
     /// Construct address from the standard representation (Base58Check).
     init(base58Check: String) throws {
-        let bytes = try Base58Check().decode(string: base58Check)
-        let versionByte = bytes[0]
-        if versionByte != accountAddressBase58CheckVersionByte {
-            throw GrpcError.unexpectedBase64CheckVersionByte(expected: accountAddressBase58CheckVersionByte, actual: versionByte)
+        var bytes = try Base58Check().decode(string: base58Check)
+        let version = bytes.removeFirst()
+        if version != accountAddressBase58CheckVersion {
+            throw GrpcError.unexpectedBase64CheckVersion(expected: accountAddressBase58CheckVersion, actual: version)
         }
-        self.bytes = bytes[1...] // exclude initial version byte
+        self.bytes = bytes // excludes initial version byte
     }
 }
 typealias SequenceNumber = UInt64

--- a/Sources/ConcordiumSwiftSDK/Model/Account.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Account.swift
@@ -21,7 +21,3 @@ struct NextAccountSequenceNumber {
     let sequenceNumber: SequenceNumber
     let allFinal: Bool
 }
-
-extension AccountAddress {
-
-}

--- a/Sources/ConcordiumSwiftSDK/Model/Block.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Block.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-typealias BlockHash = Data
-typealias AccountAddress = Data
-typealias SequenceNumber = UInt64
+typealias BlockHash = Data // 32 bytes
 
 enum BlockIdentifier {
     case lastFinal
@@ -47,15 +45,4 @@ enum BlockIdentifier {
             return b
         }
     }
-}
-
-struct CryptographicParameters {
-    let onChainCommitmentKey: String
-    let bulletproofGenerators: String
-    let genesisString: String
-}
-
-struct NextAccountSequenceNumber {
-    let sequenceNumber: SequenceNumber
-    let allFinal: Bool
 }

--- a/Sources/ConcordiumSwiftSDK/Model/Chain.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Chain.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct CryptographicParameters {
+    let onChainCommitmentKey: String
+    let bulletproofGenerators: String
+    let genesisString: String
+}

--- a/Sources/ConcordiumSwiftSDK/Model/Error.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Error.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-enum GrpcError: Error {
-    case unexpectedBase64CheckVersionByte(expected: UInt8, actual: UInt8)
+enum GrpcError: Error, Equatable {
+    case unexpectedBase64CheckVersion(expected: UInt8, actual: UInt8)
 }

--- a/Sources/ConcordiumSwiftSDK/Model/Error.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Error.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum GrpcError: Error {
+    case unexpectedBase64CheckVersionByte(expected: UInt8, actual: UInt8)
+}

--- a/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
+++ b/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
@@ -26,9 +26,7 @@ final class ClientTests: XCTestCase {
         
         let client = Client(channel: channel)
         let hash = try BlockHash(fromHexString: "a21c1c18b70c64680a4eceea655ab68d164e8f1c82b8b8566388391d8da81e41")
-        let res = await client.getCryptographicParameters(at: .hash(hash))
-        let params = try await res.get()
-        print(params)
-        
+        let res = try await client.getCryptographicParameters(at: .hash(hash))
+        print(res)
     }
 }

--- a/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
+++ b/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
@@ -7,6 +7,8 @@ import NIOPosix
 /// Temporary test for exercising the gRPC client. To run, adjust the channel target to point to a running node.
 final class ClientTests: XCTestCase {
     let channelTarget = ConnectionTarget.host("localhost", port: 20000)
+    let someBlockHash = "a21c1c18b70c64680a4eceea655ab68d164e8f1c82b8b8566388391d8da81e41"
+    let someAccountAddr = "35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh"
 
     func testClientGetCryptographicParameters() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -25,8 +27,30 @@ final class ClientTests: XCTestCase {
         }
         
         let client = Client(channel: channel)
-        let hash = try BlockHash(fromHexString: "a21c1c18b70c64680a4eceea655ab68d164e8f1c82b8b8566388391d8da81e41")
+        let hash = try BlockHash(fromHexString: someBlockHash)
         let res = try await client.getCryptographicParameters(at: .hash(hash))
+        print(res)
+    }
+    
+    func testClientGetNextAccountSequenceNumber() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        // Make sure the group is shutdown when we're done with it.
+        defer {
+          try! group.syncShutdownGracefully()
+        }
+        let channel = try GRPCChannelPool.with(
+            target: channelTarget,
+            transportSecurity: .plaintext,
+            eventLoopGroup: group
+        )
+        // Close the connection when we're done with it.
+        defer {
+          try! channel.close().wait()
+        }
+        
+        let client = Client(channel: channel)
+        let addr = try AccountAddress(base58Check: someAccountAddr)
+        let res = try await client.getNextAccountSequenceNumber(of: addr)
         print(res)
     }
 }

--- a/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
+++ b/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
@@ -8,11 +8,10 @@ import NIOPosix
 final class ClientTests: XCTestCase {
     let channelTarget = ConnectionTarget.host("localhost", port: 20000)
     let someBlockHash = "a21c1c18b70c64680a4eceea655ab68d164e8f1c82b8b8566388391d8da81e41"
-    let someAccountAddr = "35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh"
+    let someAccountAddress = "35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh"
 
     func testClientGetCryptographicParameters() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        // Make sure the group is shutdown when we're done with it.
         defer {
           try! group.syncShutdownGracefully()
         }
@@ -21,7 +20,6 @@ final class ClientTests: XCTestCase {
             transportSecurity: .plaintext,
             eventLoopGroup: group
         )
-        // Close the connection when we're done with it.
         defer {
           try! channel.close().wait()
         }
@@ -34,7 +32,6 @@ final class ClientTests: XCTestCase {
     
     func testClientGetNextAccountSequenceNumber() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        // Make sure the group is shutdown when we're done with it.
         defer {
           try! group.syncShutdownGracefully()
         }
@@ -43,13 +40,12 @@ final class ClientTests: XCTestCase {
             transportSecurity: .plaintext,
             eventLoopGroup: group
         )
-        // Close the connection when we're done with it.
         defer {
           try! channel.close().wait()
         }
         
         let client = Client(channel: channel)
-        let addr = try AccountAddress(base58Check: someAccountAddr)
+        let addr = try AccountAddress(base58Check: someAccountAddress)
         let res = try await client.getNextAccountSequenceNumber(of: addr)
         print(res)
     }

--- a/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
+++ b/Tests/ConcordiumSwiftSDKTests/ClientTests.swift
@@ -1,10 +1,15 @@
 @testable import ConcordiumSwiftSDK
-import XCTest
-
 import GRPC
 import NIOPosix
+import XCTest
 
-/// Temporary test for exercising the gRPC client. To run, adjust the channel target to point to a running node.
+/// Temporary test for exercising the gRPC client. Note that there are no assertions on the result; it's only printed for manual inspection.
+///
+/// To run one or more tests, adjust the channel target static field to point to a running node.
+/// Alternatively, run the following command in a terminal to make the OS automatically
+/// forward requests for localhost:20000 to [IP]:[port]:
+///
+///     socat TCP-LISTEN:20000,fork TCP:[IP]:[port]
 final class ClientTests: XCTestCase {
     let channelTarget = ConnectionTarget.host("localhost", port: 20000)
     let someBlockHash = "a21c1c18b70c64680a4eceea655ab68d164e8f1c82b8b8566388391d8da81e41"
@@ -23,7 +28,6 @@ final class ClientTests: XCTestCase {
         defer {
           try! channel.close().wait()
         }
-        
         let client = Client(channel: channel)
         let hash = try BlockHash(fromHexString: someBlockHash)
         let res = try await client.getCryptographicParameters(at: .hash(hash))
@@ -43,7 +47,6 @@ final class ClientTests: XCTestCase {
         defer {
           try! channel.close().wait()
         }
-        
         let client = Client(channel: channel)
         let addr = try AccountAddress(base58Check: someAccountAddress)
         let res = try await client.getNextAccountSequenceNumber(of: addr)

--- a/Tests/ConcordiumSwiftSDKTests/Model/AccountTest.swift
+++ b/Tests/ConcordiumSwiftSDKTests/Model/AccountTest.swift
@@ -1,0 +1,17 @@
+@testable import ConcordiumSwiftSDK
+import Foundation
+import XCTest
+
+final class AddressTest: XCTestCase {
+    
+    func testCanParseValidAddressString() async throws {
+        let a = try AccountAddress(base58Check: "35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh")
+        // Bytes corresponding to the decoded adderess. Computed using the Rust SDK.
+        let expected = Data([16, 234, 195, 243, 10, 162, 72, 149, 8, 200, 110, 176, 147, 40, 255, 138, 84, 117, 249, 254, 92, 148, 88, 204, 60, 112, 149, 111, 207, 203, 34, 191])
+        XCTAssertEqual(a.bytes, expected)
+    }
+    
+    func testCannotParseInvalidAddressString() async throws {
+        XCTAssertThrowsError(try AccountAddress(base58Check: "invalid"))
+    }
+}

--- a/Tests/ConcordiumSwiftSDKTests/Model/AccountTest.swift
+++ b/Tests/ConcordiumSwiftSDKTests/Model/AccountTest.swift
@@ -1,3 +1,4 @@
+import Base58Check
 @testable import ConcordiumSwiftSDK
 import Foundation
 import XCTest
@@ -12,6 +13,15 @@ final class AddressTest: XCTestCase {
     }
     
     func testCannotParseInvalidAddressString() async throws {
-        XCTAssertThrowsError(try AccountAddress(base58Check: "invalid"))
+        XCTAssertThrowsError(try AccountAddress(base58Check: "invalid")) { err in
+            XCTAssertEqual(err as! Base58CheckError, Base58CheckError.invalidDecoding)
+        }
+    }
+    
+    func testCannotParseAddressStringWithInvalidVersionByte() async throws {
+        // Same address as above but with Base58Check version byte 2.
+        XCTAssertThrowsError(try AccountAddress(base58Check: "51wUd1qZ9UKhiJQwab17sb5F3XgEy6vravJ2GPEHNYjHpncAjG")) { err in
+            XCTAssertEqual(err as! GrpcError, GrpcError.unexpectedBase64CheckVersion(expected: 1, actual: 2))
+        }
     }
 }


### PR DESCRIPTION
- Remove `getBlockHashInput` which is no longer used.
- Organize model by component,
- Let client methods return the domain object (as async) instead of being wrapped in `EventLoopFuture`. This uses `get` which adds some restrictions on supported macOS versions, but all recent versions are still supported.
- Add test for `getNextAccountSequenceNumber`.
- Wrap `AccountAddress` in type that allows easier conversion to/from bytes (included the latter). Note that the used library is not well known so should probably be vetted before used in production.