### PR TITLE
grpc: Create identity request

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -55,6 +55,15 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
       "identity" : "swift-http-types",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         ],
         dependencies: [
             .package(url: "https://github.com/anquii/Base58Check.git", from: "1.0.0"),
+            .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
             .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.15.0"),
             .package(url: "https://github.com/nicklockwood/SwiftFormat.git", exact: "0.53.0"),
         ],
@@ -24,6 +25,7 @@ let package = Package(
                     name: "ConcordiumSwiftSDK",
                     dependencies: [
                         "Base58Check",
+                        "CryptoKit",
                         .product(name: "GRPC", package: "grpc-swift"),
                         "SwiftFormat",
                     ]

--- a/Sources/ConcordiumSwiftSDK/Model/Account.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Account.swift
@@ -94,6 +94,7 @@ public typealias AttributeKind = Data
 public typealias AccountThreshold = UInt32
 
 /// An ed25519 public key.
+// TODO: Should we use Curve25519.Signing.PublicKey here instead (or maybe even skip the typealias altogether)?
 public typealias PublicKey = Data
 
 func dateFromUnixTimeMillis(_ timestamp: UInt64) -> Date {

--- a/Sources/ConcordiumSwiftSDK/Model/Chain.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Chain.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CryptographicParameters {
+public struct CryptographicParameters: Codable {
     let onChainCommitmentKey: String
     let bulletproofGenerators: String
     let genesisString: String

--- a/Sources/ConcordiumSwiftSDK/Model/Identity.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Identity.swift
@@ -1,41 +1,63 @@
+import CryptoKit
 import Foundation
 
-
-public class IdentityRequestInput {
-    private var globalContext: CryptographicParameters?
-    private var arsInfos: [String: AnonymityRevokerInfo]?
-    private var ipInfo: IdentityProviderInfo?
+public struct IdentityRequestInput: Codable {
+    let globalContext: CryptographicParameters?
+    let arsInfos: [String: AnonymityRevokerInfo]?
+    let ipInfo: IdentityProviderInfo?
     private var arThreshold: Int64
     private var idCredSec: String?
     private var prfKey: String?
     private var blindingRandomness: String?
-
-    init(globalContext: CryptographicParameters?,
-         arsInfos: [String: AnonymityRevokerInfo]?,
-         ipInfo: IdentityProviderInfo?,
-         arThreshold: Int64,
-         idCredSec: String?,
-         prfKey: String?,
-         blindingRandomness: String?) {
-        self.globalContext = globalContext
-        self.arsInfos = arsInfos
-        self.ipInfo = ipInfo
-        self.arThreshold = arThreshold
-        self.idCredSec = idCredSec
-        self.prfKey = prfKey
-        self.blindingRandomness = blindingRandomness
-    }
 }
 
 struct IdentityProviderInfo: Codable {
     let ipIdentity: UInt32
     let description: Description
-    let ipCdiVerifyKey: ED25519PublicKey
-    let ipVerifyKey: PSPublicKey
+    let ipCdiVerifyKey: Curve25519.Signing.PrivateKey
+    let ipVerifyKey: Curve25519.Signing.PublicKey
+
+    private enum CodingKeys: String, CodingKey {
+        case ipIdentity
+        case description
+        case ipCdiVerifyKey
+        case ipVerifyKey
+    }
+
+    // TODO: Do we need to decode at all - isn't it a one-way street?
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ipIdentity = try container.decode(UInt32.self, forKey: .ipIdentity)
+        description = try container.decode(Description.self, forKey: .description)
+
+        let ipCdiVerifyKeyData = try container.decode(Data.self, forKey: .ipCdiVerifyKey)
+        ipCdiVerifyKey = try Curve25519.Signing.PrivateKey(rawRepresentation: ipCdiVerifyKeyData)
+
+        let ipVerifyKeyData = try container.decode(Data.self, forKey: .ipVerifyKey)
+        ipVerifyKey = try Curve25519.Signing.PublicKey(rawRepresentation: ipVerifyKeyData)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(ipIdentity, forKey: .ipIdentity)
+        try container.encode(description, forKey: .description)
+
+        let ipCdiVerifyKeyData = ipCdiVerifyKey.rawRepresentation
+        try container.encode(ipCdiVerifyKeyData, forKey: .ipCdiVerifyKey)
+
+        let ipVerifyKeyData = ipVerifyKey.rawRepresentation
+        try container.encode(ipVerifyKeyData, forKey: .ipVerifyKey)
+    }
 }
 
 public struct AnonymityRevokerInfo: Codable {
     let arIdentity: UInt32
     let arDescription: Description
     let arPublicKey: ElgamalPublicKey
+}
+
+public struct Description: Codable {
+    let name: String
+    let url: String
+    let description: String
 }

--- a/Sources/ConcordiumSwiftSDK/Model/Identity.swift
+++ b/Sources/ConcordiumSwiftSDK/Model/Identity.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+
+public class IdentityRequestInput {
+    private var globalContext: CryptographicParameters?
+    private var arsInfos: [String: AnonymityRevokerInfo]?
+    private var ipInfo: IdentityProviderInfo?
+    private var arThreshold: Int64
+    private var idCredSec: String?
+    private var prfKey: String?
+    private var blindingRandomness: String?
+
+    init(globalContext: CryptographicParameters?,
+         arsInfos: [String: AnonymityRevokerInfo]?,
+         ipInfo: IdentityProviderInfo?,
+         arThreshold: Int64,
+         idCredSec: String?,
+         prfKey: String?,
+         blindingRandomness: String?) {
+        self.globalContext = globalContext
+        self.arsInfos = arsInfos
+        self.ipInfo = ipInfo
+        self.arThreshold = arThreshold
+        self.idCredSec = idCredSec
+        self.prfKey = prfKey
+        self.blindingRandomness = blindingRandomness
+    }
+}
+
+struct IdentityProviderInfo: Codable {
+    let ipIdentity: UInt32
+    let description: Description
+    let ipCdiVerifyKey: ED25519PublicKey
+    let ipVerifyKey: PSPublicKey
+}
+
+public struct AnonymityRevokerInfo: Codable {
+    let arIdentity: UInt32
+    let arDescription: Description
+    let arPublicKey: ElgamalPublicKey
+}


### PR DESCRIPTION
## Purpose

Implementation of (part of) https://concordium.atlassian.net/browse/CBW-1553. More specifically, this PR creates the DTOs to support serializing data when sending a "create identity" request.  

## Changes

Added codable types to support sending "create identity" requests. The `IdentityRequestInput` from the Java SDK was used as the recipe.  

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
