### PR TITLE
Refactor: Example CLI naming fix and various cleanup

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Check out sources
       uses: actions/checkout@v4
     - name: Check formatting
-      run: swift package plugin --allow-writing-to-package-directory swiftformat --lint
+      run: swift package plugin --allow-writing-to-package-directory swiftformat ./examples --lint
     - name: Build project
       run: swift build
     - name: Run tests

--- a/Sources/Concordium/Model/GRPCError.swift
+++ b/Sources/Concordium/Model/GRPCError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum GRPCError: Error, Equatable {
-    case missingBase58CheckVersion(expected: UInt8, actual: UInt8)
+    case unexpectedBase58CheckVersion(expected: UInt8, actual: UInt8)
     case missingRequiredValue(String)
     case unsupportedValue(String)
     case valueOutOfBounds

--- a/Sources/Concordium/WalletSeed.swift
+++ b/Sources/Concordium/WalletSeed.swift
@@ -2,36 +2,42 @@ import ConcordiumWalletCrypto
 import CryptoKit
 import Foundation
 
+public typealias IdentityIndex = UInt32
+public typealias CredentialCounter = UInt8
+public typealias IssuerIndex = UInt64
+public typealias IssuerSubindex = UInt64
+public typealias VerifiableCredentialIndex = UInt32
+
 public enum Network: String {
     case mainnet = "Mainnet"
     case testnet = "Testnet"
 }
 
 public struct IdentitySeedIndexes {
-    public var providerIndex: UInt32
-    public var index: UInt32
+    public var providerID: IdentityProviderID
+    public var index: IdentityIndex
 
-    public init(providerIndex: UInt32, index: UInt32) {
-        self.providerIndex = providerIndex
+    public init(providerID: IdentityProviderID, index: IdentityIndex) {
+        self.providerID = providerID
         self.index = index
     }
 }
 
 public struct AccountCredentialSeedIndexes {
     public var identity: IdentitySeedIndexes
-    public var counter: UInt8
+    public var counter: CredentialCounter
 
-    public init(identity: IdentitySeedIndexes, counter: UInt8) {
+    public init(identity: IdentitySeedIndexes, counter: CredentialCounter) {
         self.identity = identity
         self.counter = counter
     }
 }
 
 public struct IssuerSeedIndexes {
-    public var index: UInt64
-    public var subindex: UInt64
+    public var index: IssuerIndex
+    public var subindex: IssuerSubindex
 
-    public init(index: UInt64, subindex: UInt64) {
+    public init(index: IssuerIndex, subindex: IssuerSubindex) {
         self.index = index
         self.subindex = subindex
     }
@@ -39,9 +45,9 @@ public struct IssuerSeedIndexes {
 
 public struct VerifiableCredentialSeedIndexes {
     public var issuer: IssuerSeedIndexes
-    public var index: UInt32
+    public var index: VerifiableCredentialIndex
 
-    public init(issuer: IssuerSeedIndexes, index: UInt32) {
+    public init(issuer: IssuerSeedIndexes, index: VerifiableCredentialIndex) {
         self.issuer = issuer
         self.index = index
     }
@@ -61,7 +67,7 @@ public class WalletSeed {
         try identityCredSecHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: identityIndexes.providerIndex,
+            identityProviderIndex: identityIndexes.providerID,
             identityIndex: identityIndexes.index
         )
     }
@@ -70,7 +76,7 @@ public class WalletSeed {
         try identityPrfKeyHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: identityIndexes.providerIndex,
+            identityProviderIndex: identityIndexes.providerID,
             identityIndex: identityIndexes.index
         )
     }
@@ -79,7 +85,7 @@ public class WalletSeed {
         try identityAttributesSignatureBlindingRandomnessHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: identityIndexes.providerIndex,
+            identityProviderIndex: identityIndexes.providerID,
             identityIndex: identityIndexes.index
         )
     }
@@ -88,7 +94,7 @@ public class WalletSeed {
         try accountCredentialSigningKeyHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: accountCredentialIndexes.identity.providerIndex,
+            identityProviderIndex: accountCredentialIndexes.identity.providerID,
             identityIndex: accountCredentialIndexes.identity.index,
             credentialCounter: accountCredentialIndexes.counter
         )
@@ -98,7 +104,7 @@ public class WalletSeed {
         try accountCredentialPublicKeyHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: accountCredentialIndexes.identity.providerIndex,
+            identityProviderIndex: accountCredentialIndexes.identity.providerID,
             identityIndex: accountCredentialIndexes.identity.index,
             credentialCounter: accountCredentialIndexes.counter
         )
@@ -108,7 +114,7 @@ public class WalletSeed {
         try accountCredentialIdHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: accountCredentialIndexes.identity.providerIndex,
+            identityProviderIndex: accountCredentialIndexes.identity.providerID,
             identityIndex: accountCredentialIndexes.identity.index,
             credentialCounter: accountCredentialIndexes.counter,
             commitmentKey: commitmentKey
@@ -119,7 +125,7 @@ public class WalletSeed {
         try accountCredentialAttributeCommitmentRandomnessHex(
             seedHex: seedHex,
             network: network.rawValue,
-            identityProviderIndex: accountCredentialIndexes.identity.providerIndex,
+            identityProviderIndex: accountCredentialIndexes.identity.providerID,
             identityIndex: accountCredentialIndexes.identity.index,
             credentialCounter: accountCredentialIndexes.counter,
             attribute: attribute

--- a/Tests/ConcordiumTests/Model/AccountTest.swift
+++ b/Tests/ConcordiumTests/Model/AccountTest.swift
@@ -25,7 +25,7 @@ final class AddressTest: XCTestCase {
     func testCannotParseAddressStringWithInvalidVersionByte() {
         // Same address as above but with Base58Check version byte 2.
         XCTAssertThrowsError(try AccountAddress(base58Check: "51wUd1qZ9UKhiJQwab17sb5F3XgEy6vravJ2GPEHNYjHpncAjG")) { err in
-            XCTAssertEqual(err as! GRPCError, GRPCError.missingBase58CheckVersion(expected: 1, actual: 2))
+            XCTAssertEqual(err as! GRPCError, GRPCError.unexpectedBase58CheckVersion(expected: 1, actual: 2))
         }
     }
 

--- a/Tests/ConcordiumTests/WalletSeedTest.swift
+++ b/Tests/ConcordiumTests/WalletSeedTest.swift
@@ -9,7 +9,7 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .mainnet)
         XCTAssertEqual(
             try seed.credSecHex(
-                identityIndexes: IdentitySeedIndexes(providerIndex: 2, index: 115)
+                identityIndexes: IdentitySeedIndexes(providerID: 2, index: 115)
             ),
             "33b9d19b2496f59ed853eb93b9d374482d2e03dd0a12e7807929d6ee54781bb1"
         )
@@ -19,7 +19,7 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .mainnet)
         XCTAssertEqual(
             try seed.prfKeyHex(
-                identityIndexes: IdentitySeedIndexes(providerIndex: 3, index: 35)
+                identityIndexes: IdentitySeedIndexes(providerID: 3, index: 35)
             ),
             "4409e2e4acffeae641456b5f7406ecf3e1e8bd3472e2df67a9f1e8574f211bc5"
         )
@@ -29,7 +29,7 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .mainnet)
         XCTAssertEqual(
             try seed.signatureBlindingRandomnessHex(
-                identityIndexes: IdentitySeedIndexes(providerIndex: 4, index: 5713)
+                identityIndexes: IdentitySeedIndexes(providerID: 4, index: 5713)
             ),
             "1e3633af2b1dbe5600becfea0324bae1f4fa29f90bdf419f6fba1ff520cb3167"
         )
@@ -40,7 +40,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.signingKeyHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 0, index: 55),
+                    identity: IdentitySeedIndexes(providerID: 0, index: 55),
                     counter: 7
                 )
             ),
@@ -53,7 +53,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.publicKeyHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 1, index: 341),
+                    identity: IdentitySeedIndexes(providerID: 1, index: 341),
                     counter: 9
                 )
             ),
@@ -65,13 +65,13 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .mainnet)
         let privateKey = try seed.signingKeyHex(
             accountCredentialIndexes: AccountCredentialSeedIndexes(
-                identity: IdentitySeedIndexes(providerIndex: 0, index: 0),
+                identity: IdentitySeedIndexes(providerID: 0, index: 0),
                 counter: 0
             )
         )
         let publicKey = try seed.publicKeyHex(
             accountCredentialIndexes: AccountCredentialSeedIndexes(
-                identity: IdentitySeedIndexes(providerIndex: 0, index: 0),
+                identity: IdentitySeedIndexes(providerID: 0, index: 0),
                 counter: 0
             )
         )
@@ -90,7 +90,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.idHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 10, index: 50),
+                    identity: IdentitySeedIndexes(providerID: 10, index: 50),
                     counter: 5
                 ),
                 commitmentKey: "b14cbfe44a02c6b1f78711176d5f437295367aa4f2a8c2551ee10d25a03adc69d61a332a058971919dad7312e1fc94c5a8d45e64b6f917c540eee16c970c3d4b7f3caf48a7746284878e2ace21c82ea44bf84609834625be1f309988ac523fac"
@@ -104,7 +104,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.attributeCommitmentRandomnessHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 5, index: 0),
+                    identity: IdentitySeedIndexes(providerID: 5, index: 0),
                     counter: 4
                 ),
                 attribute: 0
@@ -117,7 +117,7 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .testnet)
         XCTAssertEqual(
             try seed.credSecHex(
-                identityIndexes: IdentitySeedIndexes(providerIndex: 2, index: 115)
+                identityIndexes: IdentitySeedIndexes(providerID: 2, index: 115)
             ),
             "33c9c538e362c5ac836afc08210f4b5d881ba65a0a45b7e353586dad0a0f56df"
         )
@@ -127,7 +127,7 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .testnet)
         XCTAssertEqual(
             try seed.prfKeyHex(
-                identityIndexes: IdentitySeedIndexes(providerIndex: 3, index: 35)
+                identityIndexes: IdentitySeedIndexes(providerID: 3, index: 35)
             ),
             "41d794d0b06a7a31fb79bb76c44e6b87c63e78f9afe8a772fc64d20f3d9e8e82"
         )
@@ -137,7 +137,7 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .testnet)
         XCTAssertEqual(
             try seed.signatureBlindingRandomnessHex(
-                identityIndexes: IdentitySeedIndexes(providerIndex: 4, index: 5713)
+                identityIndexes: IdentitySeedIndexes(providerID: 4, index: 5713)
             ),
             "079eb7fe4a2e89007f411ede031543bd7f687d50341a5596e015c9f2f4c1f39b"
         )
@@ -148,7 +148,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.signingKeyHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 0, index: 55),
+                    identity: IdentitySeedIndexes(providerID: 0, index: 55),
                     counter: 7
                 )
             ),
@@ -161,7 +161,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.publicKeyHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 1, index: 341),
+                    identity: IdentitySeedIndexes(providerID: 1, index: 341),
                     counter: 9
                 )
             ),
@@ -173,13 +173,13 @@ final class WalletSeedTest: XCTestCase {
         let seed = WalletSeed(seedHex: TEST_SEED, network: .testnet)
         let privateKey = try seed.signingKeyHex(
             accountCredentialIndexes: AccountCredentialSeedIndexes(
-                identity: IdentitySeedIndexes(providerIndex: 0, index: 0),
+                identity: IdentitySeedIndexes(providerID: 0, index: 0),
                 counter: 0
             )
         )
         let publicKey = try seed.publicKeyHex(
             accountCredentialIndexes: AccountCredentialSeedIndexes(
-                identity: IdentitySeedIndexes(providerIndex: 0, index: 0),
+                identity: IdentitySeedIndexes(providerID: 0, index: 0),
                 counter: 0
             )
         )
@@ -198,7 +198,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.idHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 10, index: 50),
+                    identity: IdentitySeedIndexes(providerID: 10, index: 50),
                     counter: 5
                 ),
                 commitmentKey: "b14cbfe44a02c6b1f78711176d5f437295367aa4f2a8c2551ee10d25a03adc69d61a332a058971919dad7312e1fc94c5a8d45e64b6f917c540eee16c970c3d4b7f3caf48a7746284878e2ace21c82ea44bf84609834625be1f309988ac523fac"
@@ -212,7 +212,7 @@ final class WalletSeedTest: XCTestCase {
         XCTAssertEqual(
             try seed.attributeCommitmentRandomnessHex(
                 accountCredentialIndexes: AccountCredentialSeedIndexes(
-                    identity: IdentitySeedIndexes(providerIndex: 5, index: 0),
+                    identity: IdentitySeedIndexes(providerID: 5, index: 0),
                     counter: 4
                 ),
                 attribute: 0

--- a/examples/CLI/Package.resolved
+++ b/examples/CLI/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "concordium-swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Concordium/concordium-swift-sdk.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "62c652569ba4716d6d66becc29721a403f4414e8"
+      }
+    },
+    {
       "identity" : "concordium-wallet-crypto-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Concordium/concordium-wallet-crypto-swift.git",
@@ -149,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
-        "version" : "1.25.2"
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
       }
     },
     {

--- a/examples/CLI/Package.swift
+++ b/examples/CLI/Package.swift
@@ -1,15 +1,12 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.9
 
 import Foundation
 import PackageDescription
 
 let package = Package(
-    name: "concordium",
+    name: "concordium-example-client",
     platforms: [
         .macOS(.v10_15),
-    ],
-    products: [
-        .executable(name: "concordium", targets: ["CLI"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
@@ -20,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .executableTarget(
-            name: "CLI",
+            name: "concordium-example-client",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Concordium", package: "concordium-swift-sdk"),

--- a/examples/CLI/README.md
+++ b/examples/CLI/README.md
@@ -1,35 +1,52 @@
 # CLI
 
+*Disclaimer: This tool is for testing/illustration purposes only.
+Secrets are not handled with care.*
+
 A small tool for demonstrating how to integrate the SDK as well as exercising the gRPC client
 which is otherwise hard to cover with unit tests.
 
 The interface is organized into subcommands such as
 
 ```shell
-concordium cryptographic-parameters
+concordium-example-client cryptographic-parameters
 ```
 
 for retrieving the cryptographic parameters of the chain and
 
 ```shell
-concordium account <account-address> info --block-hash=<block-hash>
+concordium-example-client account <account-address> info --block-hash=<block-hash>
 ```
 
 for retrieving information about the account `<account-address>` as of block `<block-hash>`.
 
 By default, the tool attempts to query the gRPC interface of a node running on `localhost:20000`.
-Use the options `--host` and `--ip` (or a relay tool such as `socat`) to point it somewhere else.
+Use the options `--host` and `--port` (or a relay tool such as `socat`) to point it somewhere else.
 
-Use `concordium --help` to explore the full command interface.
+Use `concordium-example-client --help` to explore the full set of commands and arguments.
 
-The script [`./test.sh`](./test.sh) invokes all available commands.
+The script [`./test.sh`](./test.sh) invokes all read-only commands.
 This will reveal if any of the commands exit with failure.
 Note, however, that it only "checks" if the commands exit successfully;
 it does not make assertions about the outputs.
-Use the environment variables `HOST` and `IP` to specify the gRPC endpoint to use in the script.
+Use the environment variables `HOST` and `PORT` to specify the gRPC endpoint to use in the script.
 
-By default, the CLI uses the SDK currently on the `main` branch.
+By default, the CLI uses the SDK currently on the `main` branch of the GitHub repository.
 Set the environment variable `CONCORDIUM_SDK_PATH` to the path of a local copy of the SDK (presumably `../..`)
 to use that instead.
 
 See the SDK's readme for an explanation of the variables to set if you need to use a local crypto library as well.
+
+## Commands
+
+All the commands support the options  `<host>` and `<port>` to configure the gRPC client as explained above.
+
+### Account Inspection
+
+See `concordium-example-client account --help` and the examples in [`./test.sh`](./test.sh).
+
+### Cryptographic Parameters
+
+```shell
+concordium-example-client --host=<host> --port=<port> cryptographic-parameters
+```

--- a/examples/CLI/Sources/commands.swift
+++ b/examples/CLI/Sources/commands.swift
@@ -50,7 +50,7 @@ struct AccountOption: ParsableArguments {
 @main
 struct Root: AsyncParsableCommand {
     @OptionGroup
-    var options: GRPCOptions
+    var opts: GRPCOptions
 
     static var configuration = CommandConfiguration(
         abstract: "A CLI for demonstrating and testing use of the gRPC client of the SDK.",
@@ -64,13 +64,13 @@ struct Root: AsyncParsableCommand {
         )
 
         @OptionGroup
-        var root: Root
+        var rootCmd: Root
 
         @OptionGroup
         var block: BlockOption
 
         func run() async throws {
-            let res = try await withGRPCClient(target: root.options.target) {
+            let res = try await withGRPCClient(target: rootCmd.opts.target) {
                 try await $0.cryptographicParameters(
                     block: block.block
                 )
@@ -94,13 +94,13 @@ struct Root: AsyncParsableCommand {
             )
 
             @OptionGroup
-            var root: Root
+            var rootCmd: Root
 
             @OptionGroup
             var accountCmd: Account
 
             func run() async throws {
-                let res = try await withGRPCClient(target: root.options.target) {
+                let res = try await withGRPCClient(target: rootCmd.opts.target) {
                     try await $0.nextAccountSequenceNumber(
                         address: accountCmd.account.address
                     )
@@ -115,7 +115,7 @@ struct Root: AsyncParsableCommand {
             )
 
             @OptionGroup
-            var root: Root
+            var rootCmd: Root
 
             @OptionGroup
             var block: BlockOption
@@ -124,7 +124,7 @@ struct Root: AsyncParsableCommand {
             var accountCmd: Account
 
             func run() async throws {
-                let res = try await withGRPCClient(target: root.options.target) {
+                let res = try await withGRPCClient(target: rootCmd.opts.target) {
                     try await $0.info(
                         account: accountCmd.account.identifier,
                         block: block.block

--- a/examples/CLI/test.sh
+++ b/examples/CLI/test.sh
@@ -9,7 +9,7 @@
 
 set -eux
 
-# Location of the gRPC interface of a Concordium Node running on mainnet.
+# Location of the gRPC interface of a Concordium Node running on testnet.
 #
 # Override via environment variables or use the following command to
 # forward traffic for the default target (localhost:20000) to <HOST>:<PORT>:
@@ -19,14 +19,14 @@ set -eux
 host="${HOST-localhost}"
 port="${PORT-20000}"
 
-# Test data (picked randomly from mainnet).
-some_block_hash="a21c1c18b70c64680a4eceea655ab68d164e8f1c82b8b8566388391d8da81e41"
-some_account_address="35CJPZohio6Ztii2zy1AYzJKvuxbGG44wrBn7hLHiYLoF2nxnh"
+# Test data (picked randomly from testnet).
+some_block_hash="970112d640a183b317f79ca9cc4db8cac3f1e263c68fca8c19d14b9fd2041a74"
+some_account_address="33Po4Z5v4DaAHo9Gz9Afc9LRzbZmYikus4Q7gqMaXHtdS17khz"
 
 # Build CLI.
 swift build
 dir_path="$(swift build --show-bin-path)"
-cli_path="${dir_path}/concordium"
+cli_path="${dir_path}/concordium-example-client"
 
 # Execute "tests".
 "${cli_path}" --host="${host}" --port="${port}" cryptographic-parameters


### PR DESCRIPTION
# Example CLI renaming

When working on the next features, we ran into a [known bug in Swift](https://github.com/apple/swift/issues/55127) that prevents the annotation `@main` from being usable from within a file named `main.swift`.

According to a [note in the docs of `ArgumentParser`](https://apple.github.io/swift-argument-parser/documentation/argumentparser/gettingstarted/) (and apparently not documented anywhere else), this shouldn't work at all:

> The Swift compiler uses either the type marked with @main or a main.swift file as the entry point for an executable program. You can use either one, but not both [...]

So it's a bit of a mystery why it works in the current version, but not once more features are added...

To fix the problem we rename `main.swift` to `commands.swift`. It also turns out that by upgrading to `swift-tools-version: 5.9`, we can abbreviate the setup to omit the "executable product" declaration and the intermediary directory inside `Sources`.

Also, the executable is renamed to `concordium-example-client` to ensure that it never is mistaken for a production ready tool.

Finally, some variables are renamed for consistency and the readme got an overhaul.

# Vaious cleanup

- Some types and variables that aren't named according to the official [API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/) but were missed in https://github.com/Concordium/concordium-swift-sdk/pull/21 have been renamed appropriately.
- New type aliases for identity parameters are added.
- The intermediate type `VerifyKeyGrpc` is replaced with an extension `fromGRPCType` on `VerifyKey` from `ConcordiumWalletCrypto`.
- The functions the convert values from the generated gRPC types have been tightened up to not accept `nil` values and ensure that optional values are explicitly handled at the right place.