### PR TITLE
Implement transfer transaction

### DIFF
--- a/Sources/Concordium/LegacyWalletExport.swift
+++ b/Sources/Concordium/LegacyWalletExport.swift
@@ -1,0 +1,169 @@
+import CommonCrypto
+import Foundation
+
+public struct LegacyWalletEncryptedExportJSON: Decodable {
+    public var cipherText: Data // base64
+    var metadata: Metadata
+
+    enum CodingKeys: CodingKey {
+        case cipherText
+        case metadata
+    }
+
+    public struct Metadata: Decodable {
+        var encryptionMethod: String
+        var initializationVector: Data // base64
+        var iterations: Int
+        var keyDerivationMethod: String
+        var salt: Data // base64
+    }
+}
+
+public struct LegacyWalletExportJSON: Decodable {
+    public var environment: String
+    public var value: Value
+
+    enum CodingKeys: CodingKey {
+        case v
+        case type
+        case environment
+        case value
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        guard type == "concordium-mobile-wallet-data" else {
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "unsupported export type '\(type)'")
+        }
+        let version = try container.decode(Int.self, forKey: .v)
+        guard version == 1 else {
+            throw DecodingError.dataCorruptedError(forKey: .v, in: container, debugDescription: "unsupported export version '\(version)'")
+        }
+        environment = try container.decode(String.self, forKey: .environment)
+        value = try container.decode(Value.self, forKey: .value)
+    }
+
+    public func toSDKType() throws -> [Concordium.Account] {
+        try value.identities.flatMap {
+            try $0.accounts.map { account in
+                try Concordium.Account(
+                    address: AccountAddress(base58Check: account.address),
+                    keys: account.accountKeys.toSDKType()
+                )
+            }
+        }
+    }
+
+    public struct Value: Decodable {
+        public var identities: [Identity]
+    }
+
+    public struct Identity: Decodable {
+        public var accounts: [Account]
+    }
+
+    public struct Account: Decodable {
+        public var address: String
+        public var accountKeys: AccountKeysJSON
+    }
+}
+
+enum DecryptExportError: Error {
+    case keyGenerationFailed(status: Int)
+    case decryptionFailed(status: CCCryptorStatus)
+    case unsupportedEncryptionMethod(String)
+    case unsupportedKeyDerivationMethod(String)
+    case unsupportedKeyLength
+    case unsupportedInputVectorLength
+    case invalidCipher(String)
+    case invalidSalt(String)
+    case invalidInitializationVector(String)
+    case invalidPasswordOrCorrupted
+}
+
+public func decryptLegacyWalletExport(export: LegacyWalletEncryptedExportJSON, password: Data) throws -> LegacyWalletExportJSON {
+    let data = try decryptLegacyWalletExport(cipher: export.cipherText, metadata: export.metadata, password: password)
+    guard String(data: data, encoding: .utf8) != nil else {
+        // Decrypted payload is not valid UTF-8.
+        throw DecryptExportError.invalidPasswordOrCorrupted
+    }
+    return try JSONDecoder().decode(LegacyWalletExportJSON.self, from: data)
+}
+
+func decryptLegacyWalletExport(cipher: Data, metadata: LegacyWalletEncryptedExportJSON.Metadata, password: Data) throws -> Data {
+    guard metadata.keyDerivationMethod == "PBKDF2WithHmacSHA256" else {
+        throw DecryptExportError.unsupportedKeyDerivationMethod(metadata.keyDerivationMethod)
+    }
+    guard metadata.encryptionMethod == "AES-256" else {
+        throw DecryptExportError.unsupportedEncryptionMethod(metadata.encryptionMethod)
+    }
+    return try decryptLegacyWalletExport(
+        cipher: cipher,
+        salt: metadata.salt,
+        iterations: metadata.iterations,
+        iv: metadata.initializationVector,
+        password: password
+    )
+}
+
+func decryptLegacyWalletExport(cipher: Data, salt: Data, iterations: Int, iv: Data, password: Data) throws -> Data {
+    try decryptAES256(
+        key: deriveKeyAES256(password: password, salt: salt, rounds: iterations),
+        iv: iv,
+        cipher
+    )
+}
+
+func deriveKeyAES256(password: Data, salt: Data, rounds: Int) throws -> Data {
+    var res = Data(repeating: 0, count: kCCKeySizeAES256)
+    let status = password.withUnsafeBytes { passwordBytes in
+        salt.withUnsafeBytes { saltBytes in
+            res.withUnsafeMutableBytes { resBytes in
+                CCKeyDerivationPBKDF(
+                    CCPBKDFAlgorithm(kCCPBKDF2),
+                    passwordBytes.baseAddress,
+                    passwordBytes.count,
+                    saltBytes.baseAddress,
+                    saltBytes.count,
+                    CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                    UInt32(rounds),
+                    resBytes.baseAddress,
+                    kCCKeySizeAES256
+                )
+            }
+        }
+    }
+    guard status == 0 else {
+        throw DecryptExportError.keyGenerationFailed(status: Int(status))
+    }
+    return res
+}
+
+func decryptAES256(key: Data, iv: Data, _ input: Data) throws -> Data {
+    guard key.count == kCCKeySizeAES256 else {
+        throw DecryptExportError.unsupportedKeyLength
+    }
+    guard iv.count == kCCBlockSizeAES128 else {
+        throw DecryptExportError.unsupportedInputVectorLength
+    }
+    var data = [UInt8](repeating: 0, count: input.count + kCCBlockSizeAES128)
+    var count = 0
+    let status = CCCrypt(
+        CCOperation(kCCDecrypt),
+        CCAlgorithm(kCCAlgorithmAES),
+        CCOptions(kCCOptionPKCS7Padding),
+        [UInt8](key),
+        key.count,
+        [UInt8](iv),
+        [UInt8](input),
+        input.count,
+        &data,
+        data.count,
+        &count
+    )
+    guard status == kCCSuccess else {
+        throw DecryptExportError.decryptionFailed(status: status)
+    }
+    return Data(bytes: data, count: count)
+}

--- a/Sources/Concordium/Model/Transaction.swift
+++ b/Sources/Concordium/Model/Transaction.swift
@@ -1,12 +1,213 @@
 import ConcordiumWalletCrypto
+import CryptoKit
 import Foundation
 import NIO
+
+public func baseTransactionCost(headerByteCount: Int, payloadByteCount: Int, signatureCount: Int) -> Energy {
+    let energyPerByte = 1
+    let energyPerSignature = 100
+    let sizeCost = Energy(energyPerByte * (headerByteCount + payloadByteCount))
+    let signatureCost = Energy(energyPerSignature * signatureCount)
+    return sizeCost + signatureCost
+}
+
+public struct AccountTransaction {
+    public var sender: AccountAddress
+    public var payload: AccountTransactionPayload
+
+    public init(sender: AccountAddress, payload: AccountTransactionPayload) {
+        self.sender = sender
+        self.payload = payload
+    }
+
+    public func prepare(sequenceNumber: SequenceNumber, expiry: UInt64, signatureCount: Int) -> PreparedAccountTransaction {
+        let serializedPayload = payload.serialize()
+        // While the header size is fixed at the moment, it isn't guaranteed to stay true in the future.
+        // As the cost depends on this size, we first create the header with no energy allocated.
+        // We then serialize this header and patch the computed cost back on.
+        // Updating the energy allocation will never affect the header size.
+        var header = AccountTransactionHeader(sender: sender, sequenceNumber: sequenceNumber, maxEnergy: 0, expiry: expiry)
+        header.maxEnergy = baseTransactionCost(
+            headerByteCount: header.serialize(serializedPayloadSize: 0).count, // concrete payload size doesn't affect header size
+            payloadByteCount: serializedPayload.count,
+            signatureCount: signatureCount
+        ) + payload.cost
+        return .init(header: header, serializedPayload: serializedPayload)
+    }
+}
+
+public struct PreparedAccountTransaction {
+    public var header: AccountTransactionHeader
+    public var serializedPayload: Data
+
+    @discardableResult public func serializeInto(buffer: inout ByteBuffer) -> Int {
+        var res = 0
+        res += header.serializeInto(buffer: &buffer, serializedPayloadSize: UInt32(serializedPayload.count))
+        res += buffer.writeData(serializedPayload)
+        return res
+    }
+
+    public func serialize() -> SerializedAccountTransaction {
+        var buf = ByteBuffer()
+        serializeInto(buffer: &buf)
+        let data = Data(buffer: buf)
+        return .init(data: data)
+    }
+}
+
+public struct SerializedAccountTransaction {
+    public var data: Data
+
+    public init(data: Data) {
+        self.data = data
+    }
+
+    public var hash: Data {
+        Data(SHA256.hash(data: data))
+    }
+}
+
+public typealias Signatures = [CredentialIndex: CredentialSignatures]
+public typealias CredentialSignatures = [KeyIndex: Data]
+
+public struct SignedAccountTransaction {
+    public var transaction: PreparedAccountTransaction
+    public var signatures: Signatures
+
+    public init(transaction: PreparedAccountTransaction, signatures: Signatures) {
+        self.transaction = transaction
+        self.signatures = signatures
+    }
+
+    func toGRPCType() -> Concordium_V2_AccountTransaction {
+        var p = Concordium_V2_AccountTransactionPayload()
+        p.rawPayload = transaction.serializedPayload
+        var s = Concordium_V2_AccountTransactionSignature()
+        s.signatures = signatures.mapValues {
+            var m = Concordium_V2_AccountSignatureMap()
+            m.signatures = $0.reduce(into: [:]) { res, e in
+                var s = Concordium_V2_Signature()
+                s.value = e.value
+                res[UInt32(e.key)] = s
+            }
+            return m
+        }
+        var t = Concordium_V2_AccountTransaction()
+        t.header = transaction.header.toGRPCType()
+        t.payload = p
+//        t.payload = transaction.payload.toGRPCType()
+        t.signature = s
+        return t
+    }
+}
+
+/// Energy is used to count exact execution cost.
+/// This cost is then converted to CCD amounts.
+public typealias Energy = UInt64
 
 /// Transaction time specified as seconds since unix epoch.
 public typealias TransactionTime = UInt64
 
-public typealias Signatures = [CredentialIndex: CredentialSignatures]
-public typealias CredentialSignatures = [KeyIndex: Data]
+/// The payload for an account transaction (only transfer is supported for now).
+public enum AccountTransactionPayload {
+    case transfer(amount: MicroCCDAmount, receiver: AccountAddress)
+
+    var cost: Energy {
+        switch self {
+        case .transfer:
+            return 300
+        }
+    }
+
+    @discardableResult public func serializeInto(buffer: inout ByteBuffer) -> Int {
+        switch self {
+        case let .transfer(amount, receiver):
+            var res = 0
+            res += buffer.writeInteger(3, as: UInt8.self)
+            res += buffer.writeData(receiver.data)
+            res += buffer.writeInteger(amount, endianness: .big, as: UInt64.self)
+            return res
+        }
+    }
+
+    public func serialize() -> Data {
+        var buf = ByteBuffer()
+        serializeInto(buffer: &buf)
+        return Data(buffer: buf)
+    }
+
+    func toGRPCType() -> Concordium_V2_AccountTransactionPayload {
+        switch self {
+        case let .transfer(amount, receiver):
+            var a = Concordium_V2_Amount()
+            a.value = amount
+            var r = Concordium_V2_AccountAddress()
+            r.value = receiver.data
+            var p = Concordium_V2_TransferPayload()
+            p.amount = a
+            p.receiver = r
+            var t = Concordium_V2_AccountTransactionPayload()
+            t.transfer = p
+            return t
+        }
+    }
+}
+
+/// Header of an account transaction that contains basic data to check whether
+/// the sender and the transaction are valid. The header is shared by all transaction types.
+public struct AccountTransactionHeader {
+    /// Sender of the transaction.
+    public var sender: AccountAddress
+
+    /// Sequence number of the transaction.
+    public var sequenceNumber: SequenceNumber
+
+    /// Maximum amount of energy the transaction can take to execute.
+    public var maxEnergy: Energy
+
+    /// Latest time the transaction can included in a block.
+    public var expiry: TransactionTime
+
+    public init(sender: AccountAddress, sequenceNumber: SequenceNumber, maxEnergy: Energy, expiry: TransactionTime) {
+        self.sender = sender
+        self.sequenceNumber = sequenceNumber
+        self.maxEnergy = maxEnergy
+        self.expiry = expiry
+    }
+
+    @discardableResult public func serializeInto(buffer: inout ByteBuffer, serializedPayloadSize: UInt32) -> Int {
+        var res = 0
+        res += buffer.writeData(sender.data)
+        res += buffer.writeInteger(sequenceNumber, endianness: .big, as: UInt64.self)
+        res += buffer.writeInteger(maxEnergy, endianness: .big, as: UInt64.self)
+        res += buffer.writeInteger(serializedPayloadSize, endianness: .big, as: UInt32.self)
+        res += buffer.writeInteger(expiry, endianness: .big, as: UInt64.self)
+        return res
+    }
+
+    public func serialize(serializedPayloadSize: UInt32) -> Data {
+        var buf = ByteBuffer()
+        serializeInto(buffer: &buf, serializedPayloadSize: serializedPayloadSize)
+        return Data(buffer: buf)
+    }
+
+    func toGRPCType() -> Concordium_V2_AccountTransactionHeader {
+        var s = Concordium_V2_AccountAddress()
+        s.value = sender.data
+        var n = Concordium_V2_SequenceNumber()
+        n.value = sequenceNumber
+        var e = Concordium_V2_Energy()
+        e.value = maxEnergy
+        var x = Concordium_V2_TransactionTime()
+        x.value = expiry
+        var h = Concordium_V2_AccountTransactionHeader()
+        h.sender = s
+        h.sequenceNumber = n
+        h.energyAmount = e
+        h.expiry = x
+        return h
+    }
+}
 
 public extension AccountCredential {
     func prepareDeployment(expiry: TransactionTime) -> PreparedAccountCredentialDeployment {

--- a/Sources/Concordium/Model/Transaction.swift
+++ b/Sources/Concordium/Model/Transaction.swift
@@ -95,7 +95,6 @@ public struct SignedAccountTransaction {
         var t = Concordium_V2_AccountTransaction()
         t.header = transaction.header.toGRPCType()
         t.payload = p
-//        t.payload = transaction.payload.toGRPCType()
         t.signature = s
         return t
     }

--- a/Sources/Concordium/NodeClient.swift
+++ b/Sources/Concordium/NodeClient.swift
@@ -9,6 +9,7 @@ public protocol NodeClient {
     func anonymityRevokers(block: BlockIdentifier) async throws -> [AnonymityRevokerInfo]
     func nextAccountSequenceNumber(address: AccountAddress) async throws -> NextAccountSequenceNumber
     func info(account: AccountIdentifier, block: BlockIdentifier) async throws -> AccountInfo
+    func send(transaction: SignedAccountTransaction) async throws -> TransactionHash
     func send(deployment: SerializedSignedAccountCredentialDeployment) async throws -> TransactionHash
 }
 
@@ -62,6 +63,13 @@ public class GRPCNodeClient: NodeClient {
         req.blockHash = block.toGRPCType()
         let res = try await grpc.getAccountInfo(req).response.get()
         return try .fromGRPCType(res)
+    }
+
+    public func send(transaction: SignedAccountTransaction) async throws -> TransactionHash {
+        var req = Concordium_V2_SendBlockItemRequest()
+        req.accountTransaction = transaction.toGRPCType()
+        let res = try await grpc.sendBlockItem(req).response.get()
+        return res.value
     }
 
     public func send(deployment: SerializedSignedAccountCredentialDeployment) async throws -> TransactionHash {

--- a/Tests/ConcordiumTests/WalletTest.swift
+++ b/Tests/ConcordiumTests/WalletTest.swift
@@ -1,0 +1,51 @@
+@testable import Concordium
+import CryptoKit
+import XCTest
+
+final class WalletTest: XCTestCase {
+    let TEST_SEED = "efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860"
+    let TESTNET_CRYPTO_PARAMS = CryptographicParameters(
+        onChainCommitmentKeyHex: "b14cbfe44a02c6b1f78711176d5f437295367aa4f2a8c2551ee10d25a03adc69d61a332a058971919dad7312e1fc94c5a8d45e64b6f917c540eee16c970c3d4b7f3caf48a7746284878e2ace21c82ea44bf84609834625be1f309988ac523fac",
+        bulletproofGeneratorsHex: "", // not used in this test
+        genesisString: "" // not used in this test
+    )
+
+    func testSimpleTransfer() throws {
+        let seed = WalletSeed(seedHex: TEST_SEED, network: .testnet)
+        let gen = SeedBasedAccountDerivation(seed: seed, cryptoParams: TESTNET_CRYPTO_PARAMS)
+        let account1 = try gen.deriveAccount(
+            credentials: [AccountCredentialSeedIndexes(identity: IdentitySeedIndexes(providerID: 0, index: 0), counter: 0)]
+        )
+        let account2 = try gen.deriveAccount(
+            credentials: [AccountCredentialSeedIndexes(identity: IdentitySeedIndexes(providerID: 0, index: 0), counter: 1)]
+        )
+
+        // Construct transaction.
+        let transaction = AccountTransaction(sender: account1.address, payload: .transfer(amount: 1_000_000, receiver: account2.address))
+        let preparedTransaction = transaction.prepare(sequenceNumber: 0, expiry: 9_999_999_999, signatureCount: 1)
+
+        // Serialize transaction and compute hash.
+        let serializedTransaction = preparedTransaction.serialize()
+        XCTAssertEqual(serializedTransaction.data.hex, "ee17ee6886c47df6f62b7dd34c24c5ee193f92f4a10671113210ccc938e80e43000000000000000000000000000001f50000002900000002540be3ff03c38725b05818ad8a23d120e4f362d5e90bf790bb502415a16f0d79cc51bc962200000000000f4240")
+        let transactionHash = serializedTransaction.hash
+        XCTAssertEqual(transactionHash.hex, "56cb3bbb655c2aae88406e14ff4e77bce01d6a921bf0628e25abbeb665255864")
+
+        // Sign transaction hash and verify signature against public key of the credential used to generate account 1.
+        let signatures = try account1.keys.sign(message: transactionHash)
+        XCTAssertEqual(signatures.count, 1)
+        let signaturesCred0 = signatures[0]!
+        XCTAssertEqual(signaturesCred0.count, 1)
+        let signature = signaturesCred0[0]!
+        let account1PublicKey = try Curve25519.Signing.PublicKey(
+            rawRepresentation: Data(
+                hex: seed.publicKeyHex(
+                    accountCredentialIndexes: AccountCredentialSeedIndexes(
+                        identity: IdentitySeedIndexes(providerID: 0, index: 0),
+                        counter: 0
+                    )
+                )
+            )
+        )
+        XCTAssertTrue(account1PublicKey.isValidSignature(signature, for: transactionHash))
+    }
+}

--- a/examples/CLI/README.md
+++ b/examples/CLI/README.md
@@ -104,3 +104,33 @@ concordium-example-client wallet --seed-phrase="gospel bicycle..." --identity-pr
 
 The command uses identity recovery to fetch the identity, derives a single account credential and deploys it to the chain.
 The hash of the submitted transaction is printed to the console.
+
+#### Transfer
+
+Send 123456789 µCCD (123.456789 CCD) from the account created using the [Create Account](#create-account) command above
+to account `39MD...`.
+
+```shell
+concordium-example-client wallet --seed-phrase="gospel bicycle..." --identity-provider-id=1 --identity-index=2 transfer --credential-counter=0 --receiver=<receiver-address> --amount=123456789
+```
+
+The hash of the submitted transaction is printed to the console.
+
+### Legacy Wallet
+
+All `legacy-wallet` commands decrypt a Legacy Wallet export file to obtain the keys for the account to interact with.
+The path to the export file is provided to option `--export-file`.
+The password to decrypt the file is provided as a plain text string to the option `--export-file-password`.
+This is very insecure - production tools that serve real users must never expect sensitive information like this
+to be provided as part of the command.
+
+#### Transfer
+
+From legacy account `33Po...` stored in export file `concordium-backup.concordiumwallet` under password `xxxxxx`,
+send 123456789 µCCD (123.456789 CCD) to account `39MD...`.
+
+```shell
+concordium-example-client legacy-wallet --export-file=concordium-backup.concordiumwallet --export-file-password=xxxxxx --account="33Po..." transfer --receiver="39MD..." --amount=123456789
+```
+
+The hash of the submitted transaction is printed to the console.


### PR DESCRIPTION
Added types for representing account transactions with "transfer" being the only implemented payload type yet. The types are arranged such that you go from expressing an "intent" (i.e. to transfer C from X to Y) with `AccountTransaction` to including expiry, cost, and signatures in a logical sequence. This will end out with a `SignedAccountTransaction` which can be sent using `NodeClient`.

Convenient `sign` methods have been added for going directly from `AccountTransaction` to `SignedAccountTransaction`, such that all you have to write is

```swift
let tx = AccountTransaction(
    sender: myAccount.address,
    payload: .transfer(amount: myAmount, receiver: myReceiver)
)
// fetch next sequence number (nextSeq) of sender account
let signedTx = myAccount.keys.sign(tx, sequenceNumber: nextSeq, expiry: myExpiry)
```

See `Tests/ConcordiumTests/WalletTest.swift` for the spelled out version.

Decoding and decryption of the Legacy Wallet export file format were also implemented to make it easy to interact with legacy accounts.

Commands for performing transfers using either legacy or seed based accounts were added to the example CLI.