### PR TITLE
Document attribute tag

### DIFF
--- a/Sources/Concordium/Model/Account.swift
+++ b/Sources/Concordium/Model/Account.swift
@@ -226,7 +226,7 @@ extension Policy {
             validToYearMonth: yearMonthString(year: grpc.validTo.year, month: grpc.validTo.month),
             revealedAttributes: grpc.attributes.reduce(into: [:]) { res, e in
                 let attr = try UInt8(exactly: e.key)
-                    .flatMap { AttributeType(rawValue: $0) }
+                    .flatMap { AttributeTag(rawValue: $0) }
                     ?! GRPCError.valueOutOfBounds
                 res["\(attr)"] = String(data: e.value, encoding: .utf8) // TODO: correct to treat attribute value as UTF-8?
             }

--- a/Sources/Concordium/Model/Identity.swift
+++ b/Sources/Concordium/Model/Identity.swift
@@ -268,16 +268,16 @@ public enum AttributeTag: UInt8, CustomStringConvertible, CaseIterable {
     /// - eID string (see below)
     ///
     /// eID strings as of Apr 2024:
-    /// - DK:MITID	      : Danish MitId
-    /// - SE:BANKID	      : Swedish BankID
-    /// - NO:BANKID	      : Norwegian BankID
-    /// - NO:VIPPS	      : Norwegian Vipps
+    /// - DK:MITID        : Danish MitId
+    /// - SE:BANKID       : Swedish BankID
+    /// - NO:BANKID       : Norwegian BankID
+    /// - NO:VIPPS        : Norwegian Vipps
     /// - FI:TRUSTNETWORK : Finnish Trust Network
-    /// - NL:DIGID	      : Netherlands DigiD
-    /// - NL:IDIN	      : Netherlands iDIN
-    /// - BE:EID	      : Belgian eID
-    /// - ITSME	          : (Cross-national) ItsME
-    /// - SOFORT	      : (Cross-national) Sofort
+    /// - NL:DIGID        : Netherlands DigiD
+    /// - NL:IDIN         : Netherlands iDIN
+    /// - BE:EID          : Belgian eID
+    /// - ITSME           : (Cross-national) ItsME
+    /// - SOFORT          : (Cross-national) Sofort
     case idDocType = 6
     /// Identity document number (format: string up to 31 bytes).
     case idDocNo = 7

--- a/Sources/Concordium/Model/Identity.swift
+++ b/Sources/Concordium/Model/Identity.swift
@@ -236,28 +236,70 @@ public struct IdentityIssuanceResponse: Decodable {
     }
 }
 
-public enum AttributeType: UInt8, CustomStringConvertible, CaseIterable {
+/// The supported set of attributes which are stored on identities and optionally revealed by accounts.
+/// In some contexts (such as the gRPC API), attribute tags are represented by a byte (the raw type of this enum).
+/// Where human readability is a concern, the string representation implemented by ``description`` is used.
+/// Note that since ``AttributeList`` (which is a component of ``IdentityObject``) is defined in another library, it cannot use this type.
+/// Instead, its field `chosenAttributes` is a map from the string representation of the tag to the value.
+/// Use the appropriate initializer of this type to convert it.
+/// All attribute values are strings of 31 bytes or less. The expected format of the values is documented
+/// [here](https://docs.google.com/spreadsheets/d/1CxpFvtAoUcylHQyeBtRBaRt1zsibtpmQOVsk7bsHPGA/edit).
+public enum AttributeTag: UInt8, CustomStringConvertible, CaseIterable {
+    /// First name (format: string up to 31 bytes).
     case firstName = 0
+    /// Last name (format: string up to 31 bytes).
     case lastName = 1
+    /// Sex (format: ISO/IEC 5218).
     case sex = 2
-    case dob = 3
+    /// Date of birth (format: ISO8601 YYYYMMDD).
+    case dateOfBirth = 3
+    /// Country of residence (format: ISO3166-1 alpha-2).
     case countryOfResidence = 4
+    /// Country of nationality (format: ISO3166-1 alpha-2)
     case nationality = 5
+    /// Identity Document Type (format: na=0, passport=1, national id card=2, driving license=3, immigration card=4 or eID string).
     case idDocType = 6
+    /// Identity Document number (format: string up to 31 bytes).
     case idDocNo = 7
+    /// Identity Document Issuer (format: ISO3166-1 alpha-2 or ISO3166-2 if applicable).
     case idDocIssuer = 8
+    /// ID Valid from (format: ISO8601 YYYYMMDD).
     case idDocIssuedAt = 9
+    /// ID Valid to (format: ISO8601 YYYYMMDD).
     case idDocExpiresAt = 10
+    /// National ID number (format: string up to 31 bytes).
     case nationalIdNo = 11
+    /// Tax ID number (format: string up to 31 bytes).
     case taxIdNo = 12
-    case lei = 13
+    /// LEI-code (Company only) (format: ISO17442).
+    case legalEntityId = 13
+
+    public init?(_ description: String) {
+        switch description {
+        case "firstName": self = .firstName
+        case "lastName": self = .lastName
+        case "sex": self = .sex
+        case "dob": self = .dateOfBirth
+        case "countryOfResidence": self = .countryOfResidence
+        case "nationality": self = .nationality
+        case "idDocType": self = .idDocType
+        case "idDocNo": self = .idDocNo
+        case "idDocIssuer": self = .idDocIssuer
+        case "idDocIssuedAt": self = .idDocIssuedAt
+        case "idDocExpiresAt": self = .idDocExpiresAt
+        case "nationalIdNo": self = .nationalIdNo
+        case "taxIdNo": self = .taxIdNo
+        case "lei": self = .legalEntityId
+        default: return nil
+        }
+    }
 
     public var description: String {
         switch self {
         case .firstName: return "firstName"
         case .lastName: return "lastName"
         case .sex: return "sex"
-        case .dob: return "dob"
+        case .dateOfBirth: return "dob"
         case .countryOfResidence: return "countryOfResidence"
         case .nationality: return "nationality"
         case .idDocType: return "idDocType"
@@ -267,7 +309,7 @@ public enum AttributeType: UInt8, CustomStringConvertible, CaseIterable {
         case .idDocExpiresAt: return "idDocExpiresAt"
         case .nationalIdNo: return "nationalIdNo"
         case .taxIdNo: return "taxIdNo"
-        case .lei: return "lei"
+        case .legalEntityId: return "lei"
         }
     }
 }

--- a/Sources/Concordium/Model/Identity.swift
+++ b/Sources/Concordium/Model/Identity.swift
@@ -257,21 +257,21 @@ public enum AttributeTag: UInt8, CustomStringConvertible, CaseIterable {
     case countryOfResidence = 4
     /// Country of nationality (format: ISO3166-1 alpha-2).
     case nationality = 5
-    /// Identity Document Type (format: na=0, passport=1, national id card=2, driving license=3, immigration card=4 or eID string).
+    /// Identity document type (format: na=0, passport=1, national id card=2, driving license=3, immigration card=4, or eID string).
     case idDocType = 6
-    /// Identity Document number (format: string up to 31 bytes).
+    /// Identity document number (format: string up to 31 bytes).
     case idDocNo = 7
-    /// Identity Document Issuer (format: ISO3166-1 alpha-2 or ISO3166-2 if applicable).
+    /// Identity document issuer (format: ISO3166-1 alpha-2 or ISO3166-2 if applicable).
     case idDocIssuer = 8
-    /// ID Valid from (format: ISO8601 YYYYMMDD).
+    /// Time from which the ID is valid (format: ISO8601 YYYYMMDD).
     case idDocIssuedAt = 9
-    /// ID Valid to (format: ISO8601 YYYYMMDD).
+    /// Time to which the ID is valid (format: ISO8601 YYYYMMDD).
     case idDocExpiresAt = 10
     /// National ID number (format: string up to 31 bytes).
     case nationalIdNo = 11
     /// Tax ID number (format: string up to 31 bytes).
     case taxIdNo = 12
-    /// LEI-code (Company only) (format: ISO17442).
+    /// LEI-code - companies only (format: ISO17442).
     case legalEntityId = 13
 
     public init?(_ description: String) {

--- a/Sources/Concordium/Model/Identity.swift
+++ b/Sources/Concordium/Model/Identity.swift
@@ -255,7 +255,7 @@ public enum AttributeTag: UInt8, CustomStringConvertible, CaseIterable {
     case dateOfBirth = 3
     /// Country of residence (format: ISO3166-1 alpha-2).
     case countryOfResidence = 4
-    /// Country of nationality (format: ISO3166-1 alpha-2)
+    /// Country of nationality (format: ISO3166-1 alpha-2).
     case nationality = 5
     /// Identity Document Type (format: na=0, passport=1, national id card=2, driving license=3, immigration card=4 or eID string).
     case idDocType = 6

--- a/Sources/Concordium/Model/Identity.swift
+++ b/Sources/Concordium/Model/Identity.swift
@@ -257,7 +257,27 @@ public enum AttributeTag: UInt8, CustomStringConvertible, CaseIterable {
     case countryOfResidence = 4
     /// Country of nationality (format: ISO3166-1 alpha-2).
     case nationality = 5
-    /// Identity document type (format: na=0, passport=1, national id card=2, driving license=3, immigration card=4, or eID string).
+    /// Identity document type
+    ///
+    /// Format:
+    /// - 0 : na
+    /// - 1 : passport
+    /// - 2 : national ID card
+    /// - 3 : driving license
+    /// - 4 : immigration card
+    /// - eID string (see below)
+    ///
+    /// eID strings as of Apr 2024:
+    /// - DK:MITID	      : Danish MitId
+    /// - SE:BANKID	      : Swedish BankID
+    /// - NO:BANKID	      : Norwegian BankID
+    /// - NO:VIPPS	      : Norwegian Vipps
+    /// - FI:TRUSTNETWORK : Finnish Trust Network
+    /// - NL:DIGID	      : Netherlands DigiD
+    /// - NL:IDIN	      : Netherlands iDIN
+    /// - BE:EID	      : Belgian eID
+    /// - ITSME	          : (Cross-national) ItsME
+    /// - SOFORT	      : (Cross-national) Sofort
     case idDocType = 6
     /// Identity document number (format: string up to 31 bytes).
     case idDocNo = 7

--- a/Sources/Concordium/WalletSeed.swift
+++ b/Sources/Concordium/WalletSeed.swift
@@ -185,7 +185,7 @@ public class SeedBasedAccountDerivation {
         let idCredSecHex = try seed.credSecHex(identityIndexes: seedIndexes.identity)
         let prfKeyHex = try seed.prfKeyHex(identityIndexes: seedIndexes.identity)
         let blindingRandomnessHex = try seed.signatureBlindingRandomnessHex(identityIndexes: seedIndexes.identity)
-        let attributeRandomnessHex = try AttributeType.allCases.reduce(into: [:]) { res, attr in
+        let attributeRandomnessHex = try AttributeTag.allCases.reduce(into: [:]) { res, attr in
             res["\(attr)"] = try seed.attributeCommitmentRandomnessHex(
                 accountCredentialIndexes: seedIndexes,
                 attribute: attr.rawValue

--- a/Tests/ConcordiumTests/Model/IdentityTest.swift
+++ b/Tests/ConcordiumTests/Model/IdentityTest.swift
@@ -1,0 +1,53 @@
+@testable import Concordium
+import Foundation
+import XCTest
+
+final class IdentityTest: XCTestCase {
+    func testCanInitializeAccountTagFromValidByte() {
+        XCTAssertEqual(AttributeTag(rawValue: 0), AttributeTag.firstName)
+        XCTAssertEqual(AttributeTag(rawValue: 1), AttributeTag.lastName)
+        XCTAssertEqual(AttributeTag(rawValue: 2), AttributeTag.sex)
+        XCTAssertEqual(AttributeTag(rawValue: 3), AttributeTag.dateOfBirth)
+        XCTAssertEqual(AttributeTag(rawValue: 4), AttributeTag.countryOfResidence)
+        XCTAssertEqual(AttributeTag(rawValue: 5), AttributeTag.nationality)
+        XCTAssertEqual(AttributeTag(rawValue: 6), AttributeTag.idDocType)
+        XCTAssertEqual(AttributeTag(rawValue: 7), AttributeTag.idDocNo)
+        XCTAssertEqual(AttributeTag(rawValue: 8), AttributeTag.idDocIssuer)
+        XCTAssertEqual(AttributeTag(rawValue: 9), AttributeTag.idDocIssuedAt)
+        XCTAssertEqual(AttributeTag(rawValue: 10), AttributeTag.idDocExpiresAt)
+        XCTAssertEqual(AttributeTag(rawValue: 11), AttributeTag.nationalIdNo)
+        XCTAssertEqual(AttributeTag(rawValue: 12), AttributeTag.taxIdNo)
+        XCTAssertEqual(AttributeTag(rawValue: 13), AttributeTag.legalEntityId)
+    }
+
+    func testCannotInitializeAccountTagFromInvalidByte() {
+        XCTAssertNil(AttributeTag(rawValue: 250))
+    }
+
+    func testCanInitializeAccountTagFromValidString() {
+        XCTAssertEqual(AttributeTag("firstName"), AttributeTag.firstName)
+        XCTAssertEqual(AttributeTag("lastName"), AttributeTag.lastName)
+        XCTAssertEqual(AttributeTag("sex"), AttributeTag.sex)
+        XCTAssertEqual(AttributeTag("dob"), AttributeTag.dateOfBirth)
+        XCTAssertEqual(AttributeTag("countryOfResidence"), AttributeTag.countryOfResidence)
+        XCTAssertEqual(AttributeTag("nationality"), AttributeTag.nationality)
+        XCTAssertEqual(AttributeTag("idDocType"), AttributeTag.idDocType)
+        XCTAssertEqual(AttributeTag("idDocNo"), AttributeTag.idDocNo)
+        XCTAssertEqual(AttributeTag("idDocIssuer"), AttributeTag.idDocIssuer)
+        XCTAssertEqual(AttributeTag("idDocIssuedAt"), AttributeTag.idDocIssuedAt)
+        XCTAssertEqual(AttributeTag("idDocExpiresAt"), AttributeTag.idDocExpiresAt)
+        XCTAssertEqual(AttributeTag("lastName"), AttributeTag.lastName)
+        XCTAssertEqual(AttributeTag("taxIdNo"), AttributeTag.taxIdNo)
+        XCTAssertEqual(AttributeTag("lei"), AttributeTag.legalEntityId)
+    }
+
+    func testCannotInitializeAccountTagFromInvalidString() {
+        XCTAssertNil(AttributeTag("xxx"))
+    }
+
+    func testDescription() {
+        for a in AttributeTag.allCases {
+            XCTAssertEqual(AttributeTag(a.description), a)
+        }
+    }
+}


### PR DESCRIPTION
Renamed `AttributeType` to `AttributeTag` for consistency with the Rust SDK (it uses the former name for the type in parameterized form) and documented its relation to `AttributeList` as well as the expected formats of the attribute values (based on https://docs.google.com/spreadsheets/d/1CxpFvtAoUcylHQyeBtRBaRt1zsibtpmQOVsk7bsHPGA/edit#gid=0).

Furthermore, an initializer for the string representation as well ass complete test coverage was added.