### PR TITLE
CI: Run tests on all supported macOS runners

### DIFF
--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         runner:
-        - macos-11
-        - macos-12
-        - macos-13
-        - macos-14
+        - macos-11 # X64
+        - macos-12 # X64
+        - macos-13 # X64
+        - macos-14 # ARM64
 
     runs-on: "${{matrix.runner}}"
 

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
     - name: Check out sources
       uses: actions/checkout@v4
-    - name: Check formatting
+    - name: "[Debug]: runner.name (${{runner.name}})"
+      run: echo "${{runner.name}}"
+    - name: Check formatting (except macOS 11)
       if: runner.name != 'macos-11'
       run: swift package plugin --allow-writing-to-package-directory swiftformat ./examples --lint
     - name: Build project and run tests

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         runner:
-        - macos-11 # X64
         - macos-12 # X64
         - macos-13 # X64
         - macos-14 # ARM64
@@ -24,9 +23,7 @@ jobs:
     steps:
     - name: Check out sources
       uses: actions/checkout@v4
-    - name: "[Debug]: lint (${{matrix.lint}})"
-      run: echo
-    - name: Check formatting (except macOS 11)
+    - name: Check formatting
       if: matrix.lint
       run: swift package plugin --allow-writing-to-package-directory swiftformat ./examples --lint
     - name: Build project and run tests

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -1,30 +1,23 @@
 name: Build and test
 
 on:
-    push:
-        branches: main
-    pull_request:
-
-env:
-  swift_version: "5.9"
+  push:
+    branches: main
+  pull_request:
 
 jobs:
   build-fmt-test:
     strategy:
       matrix:
         runner:
-          - macos-11
-          - macos-12
-          - macos-13
-          - macos-14
+        - macos-11
+        - macos-12
+        - macos-13
+        - macos-14
 
     runs-on: "${{matrix.runner}}"
 
     steps:
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v1
-      with:
-        swift-version: "${{env.swift_version}}"
     - name: Check out sources
       uses: actions/checkout@v4
     - name: Check formatting

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Check out sources
       uses: actions/checkout@v4
     - name: Check formatting
+      if: runner.name != 'macos-11'
       run: swift package plugin --allow-writing-to-package-directory swiftformat ./examples --lint
     - name: Build project and run tests
       run: swift test

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -14,16 +14,20 @@ jobs:
         - macos-12 # X64
         - macos-13 # X64
         - macos-14 # ARM64
+        include:
+        - runner: macos-14
+          lint: true
+
 
     runs-on: "${{matrix.runner}}"
 
     steps:
     - name: Check out sources
       uses: actions/checkout@v4
-    - name: "[Debug]: runner.name (${{runner.name}})"
-      run: echo "${{runner.name}}"
+    - name: "[Debug]: lint (${{matrix.lint}})"
+      run: echo
     - name: Check formatting (except macOS 11)
-      if: runner.name != 'macos-11'
+      if: matrix.lint
       run: swift package plugin --allow-writing-to-package-directory swiftformat ./examples --lint
     - name: Build project and run tests
       run: swift test

--- a/.github/workflows/build+test.yml
+++ b/.github/workflows/build+test.yml
@@ -9,8 +9,16 @@ env:
   swift_version: "5.9"
 
 jobs:
-  build_fmt_test:
-    runs-on: macos-13
+  build-fmt-test:
+    strategy:
+      matrix:
+        runner:
+          - macos-11
+          - macos-12
+          - macos-13
+          - macos-14
+
+    runs-on: "${{matrix.runner}}"
 
     steps:
     - name: Setup Swift
@@ -21,7 +29,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Check formatting
       run: swift package plugin --allow-writing-to-package-directory swiftformat ./examples --lint
-    - name: Build project
-      run: swift build
-    - name: Run tests
+    - name: Build project and run tests
       run: swift test
+    - name: Build example CLI
+      working-directory: ./examples/CLI
+      run: swift build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Once this SDK is ready for production, it will completely replace this old libra
 ### Supported platforms
 
 - iOS 15+
-- macOS 10.15+
+- macOS 10.15+ (macOS 12+ to build)
 
 ## Usage
 


### PR DESCRIPTION
The lint/test job now runs on all [available](https://github.com/actions/runner-images/?tab=readme-ov-file#available-images) ("normal"-sized) macOS runners of OS versions that the SDK builds on.

In this regard, we now explicitly support building on macOS 12+, so we don't use the `macos-11` runner. This runner only supports swift-tools up to version 5.5 and we use 5.6 (downgrading would take away ability to depend on SwiftFormat by exact version).

The formatting check now only runs in a single job. This was initially done to make macOS 11 work because its version of SwiftFormat didn't support all the options in the used command, but it made sense to keep in anyway.

Finally, a check that the example CLI builds successfully was added to the job.