### PR TITLE
Add generic Amount type for amounts of arbitrary size

### DIFF
--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -5,7 +5,6 @@ public enum AmountParseError: Error {
     case invalidInput
     case negativeDecimalCount
     case tooManyFractionalDigits
-    case trailingDecimalSeparator
 }
 
 private let ten = BigUInt(10)
@@ -28,21 +27,21 @@ public struct Amount: Equatable {
             let wholePart = string[string.startIndex ..< sepIdx]
             let sepIdx1 = string.index(sepIdx, offsetBy: 1)
             let fracPart = string[sepIdx1 ..< string.endIndex]
-            try self.init(wholePart: wholePart, fracPart: fracPart, decimalCount: decimalCount)
+            try self.init(wholePart: String(wholePart), fracPart: String(fracPart), decimalCount: decimalCount)
         } else {
             try self.init(wholePart: string, decimalCount: decimalCount)
         }
     }
 
-    private init(wholePart: any StringProtocol, fracPart: (any StringProtocol)? = nil, decimalCount: Int) throws {
+    private init(wholePart: String, fracPart: String? = nil, decimalCount: Int) throws {
         guard let wp = BigUInt(wholePart) else {
             throw AmountParseError.invalidInput
         }
         var intValue = wp * ten.power(decimalCount)
         if let fracPart {
-            if fracPart.isEmpty {
-                throw AmountParseError.trailingDecimalSeparator
-            }
+//            if fracPart.isEmpty {
+//                throw AmountParseError.trailingDecimalSeparator
+//            }
             guard fracPart.count <= decimalCount else {
                 throw AmountParseError.tooManyFractionalDigits
             }
@@ -83,7 +82,7 @@ public struct Amount: Equatable {
 }
 
 public struct CCD: CustomStringConvertible {
-    private static let decimalCount = 6
+    public static let decimalCount = 6
 
     public var amount: Amount
 
@@ -100,10 +99,14 @@ public struct CCD: CustomStringConvertible {
     }
 
     public var description: String {
-        format(minDecimalDigits: 0)
+        format()
     }
 
-    public func format(minDecimalDigits: Int = 0) -> String {
-        amount.withoutTrailingZeros(minDecimalCount: minDecimalDigits).format()
+    public func format(minDecimalDigits: Int? = nil, decimalSeparator: String? = nil) -> String {
+        var a = amount
+        if let minDecimalDigits {
+            a = amount.withoutTrailingZeros(minDecimalCount: minDecimalDigits)
+        }
+        return a.format(decimalSeparator: decimalSeparator)
     }
 }

--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -23,10 +23,9 @@ public struct Amount: Equatable {
 
     public init(_ string: String, decimalCount: UInt16, decimalSeparator: String? = nil) throws {
         let sep = Self.resolveDecimalSeparator(decimalSeparator)
-        if let sepIdx = string.firstIndex(of: sep[sep.startIndex]) {
-            let wholePart = string[string.startIndex ..< sepIdx]
-            let sepIdx1 = string.index(sepIdx, offsetBy: 1)
-            let fracPart = string[sepIdx1 ..< string.endIndex]
+        if let sepRange = string.range(of: sep) {
+            let wholePart = string[string.startIndex ..< sepRange.lowerBound]
+            let fracPart = string[sepRange.upperBound ..< string.endIndex]
             try self.init(wholePart: String(wholePart), fracPart: String(fracPart), decimalCount: decimalCount)
         } else {
             try self.init(wholePart: string, decimalCount: decimalCount)

--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -3,34 +3,34 @@ import Foundation
 
 public enum AmountParseError: Error {
     case invalidInput
-    case negativeDecimals
-    case fractionPartTooLong
-    case inputTooLarge
+    case negativeDecimalCount
+    case tooManyFractionalDigits
+    case trailingDecimalSeparator
 }
 
 private let ten = BigUInt(10)
 
-public struct Amount {
+public struct Amount: Equatable {
     public var intValue: BigUInt
     public var decimalCount: Int
 
-    public init(intValue: BigUInt, decimalCount: Int) {
+    public init(_ intValue: BigUInt, decimalCount: Int) {
         self.intValue = intValue
         self.decimalCount = decimalCount
     }
 
-    public init(input: String, decimalCount: Int, decimalSeparator: String? = nil) throws {
+    public init(_ string: String, decimalCount: Int, decimalSeparator: String? = nil) throws {
         guard decimalCount >= 0 else {
-            throw AmountParseError.negativeDecimals
+            throw AmountParseError.negativeDecimalCount
         }
         let sep = Self.resolveDecimalSeparator(decimalSeparator)
-        if let sepIdx = input.firstIndex(of: sep[sep.startIndex]) {
-            let wholePart = input[input.startIndex ..< sepIdx]
-            let sepIdx1 = input.index(sepIdx, offsetBy: 1)
-            let fracPart = input[sepIdx1 ..< input.endIndex]
+        if let sepIdx = string.firstIndex(of: sep[sep.startIndex]) {
+            let wholePart = string[string.startIndex ..< sepIdx]
+            let sepIdx1 = string.index(sepIdx, offsetBy: 1)
+            let fracPart = string[sepIdx1 ..< string.endIndex]
             try self.init(wholePart: wholePart, fracPart: fracPart, decimalCount: decimalCount)
         } else {
-            try self.init(wholePart: input, decimalCount: decimalCount)
+            try self.init(wholePart: string, decimalCount: decimalCount)
         }
     }
 
@@ -40,33 +40,41 @@ public struct Amount {
         }
         var intValue = wp * ten.power(decimalCount)
         if let fracPart {
+            if fracPart.isEmpty {
+                throw AmountParseError.trailingDecimalSeparator
+            }
+            guard fracPart.count <= decimalCount else {
+                throw AmountParseError.tooManyFractionalDigits
+            }
             guard let fp = BigUInt(fracPart) else {
                 throw AmountParseError.invalidInput
             }
             intValue += fp * ten.power(decimalCount - fracPart.count)
+        } else if wholePart.isEmpty {
+            throw AmountParseError.invalidInput
         }
-        self.init(intValue: intValue, decimalCount: decimalCount)
+        self.init(intValue, decimalCount: decimalCount)
     }
 
-    public func format(minDecimalDigits: Int, decimalSeparator: String? = nil) -> String {
+    public func withoutTrailingZeros(minDecimalCount: Int) -> Amount {
         var v = intValue
         var d = decimalCount
-        while d > minDecimalDigits, v % 10 == 0 {
+        while d > minDecimalCount, v % 10 == 0 {
             v /= 10
             d -= 1
         }
-        return Self.format(value: v, subunitPrecision: d, decimalSeparator: decimalSeparator)
+        return Amount(v, decimalCount: d)
     }
 
-    public static func format(value: BigUInt, subunitPrecision: Int, decimalSeparator: String? = nil) -> String {
-        if subunitPrecision == 0 {
-            return String(value)
+    public func format(decimalSeparator: String? = nil) -> String {
+        if decimalCount == 0 {
+            return String(intValue)
         }
-        let divisor = ten.power(subunitPrecision)
-        let int = String(value / divisor)
-        let frac = String(value % divisor)
-        let padding = String(repeating: "0", count: subunitPrecision - frac.count)
-        return "\(int)\(resolveDecimalSeparator(decimalSeparator))\(padding)\(frac)"
+        let divisor = ten.power(decimalCount)
+        let int = String(intValue / divisor)
+        let frac = String(intValue % divisor)
+        let padding = String(repeating: "0", count: decimalCount - frac.count)
+        return "\(int)\(Self.resolveDecimalSeparator(decimalSeparator))\(padding)\(frac)"
     }
 
     private static func resolveDecimalSeparator(_ provided: String?) -> String {
@@ -80,11 +88,11 @@ public struct CCD: CustomStringConvertible {
     public var amount: Amount
 
     public init(microCCD: MicroCCDAmount) {
-        amount = .init(intValue: BigUInt(microCCD), decimalCount: Self.decimalCount)
+        amount = .init(BigUInt(microCCD), decimalCount: Self.decimalCount)
     }
 
     public init(_ string: String) throws {
-        amount = try .init(input: string, decimalCount: Self.decimalCount)
+        amount = try .init(string, decimalCount: Self.decimalCount)
     }
 
     public var microCCDAmount: MicroCCDAmount {
@@ -96,6 +104,6 @@ public struct CCD: CustomStringConvertible {
     }
 
     public func format(minDecimalDigits: Int = 0) -> String {
-        amount.format(minDecimalDigits: minDecimalDigits)
+        amount.withoutTrailingZeros(minDecimalCount: minDecimalDigits).format()
     }
 }

--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -10,11 +10,11 @@ public enum AmountParseError: Error {
 private let ten = BigUInt(10)
 
 public struct Amount: Equatable {
-    public var intValue: BigUInt
+    public var value: BigUInt
     public var decimalCount: Int
 
     public init(_ intValue: BigUInt, decimalCount: Int) {
-        self.intValue = intValue
+        value = intValue
         self.decimalCount = decimalCount
     }
 
@@ -56,7 +56,7 @@ public struct Amount: Equatable {
     }
 
     public func withoutTrailingZeros(minDecimalCount: Int) -> Amount {
-        var v = intValue
+        var v = value
         var d = decimalCount
         while d > minDecimalCount, v % 10 == 0 {
             v /= 10
@@ -67,11 +67,11 @@ public struct Amount: Equatable {
 
     public func format(decimalSeparator: String? = nil) -> String {
         if decimalCount == 0 {
-            return String(intValue)
+            return String(value)
         }
         let divisor = ten.power(decimalCount)
-        let int = String(intValue / divisor)
-        let frac = String(intValue % divisor)
+        let int = String(value / divisor)
+        let frac = String(value % divisor)
         let padding = String(repeating: "0", count: decimalCount - frac.count)
         return "\(int)\(Self.resolveDecimalSeparator(decimalSeparator))\(padding)\(frac)"
     }
@@ -90,12 +90,15 @@ public struct CCD: CustomStringConvertible {
         amount = .init(BigUInt(microCCD), decimalCount: Self.decimalCount)
     }
 
-    public init(_ string: String) throws {
-        amount = try .init(string, decimalCount: Self.decimalCount)
+    public init(_ string: String, decimalSeparator: String? = nil) throws {
+        amount = try .init(string, decimalCount: Self.decimalCount, decimalSeparator: decimalSeparator)
     }
 
-    public var microCCDAmount: MicroCCDAmount {
-        MicroCCDAmount(amount.intValue)
+    public var microCCDAmount: MicroCCDAmount? {
+        guard amount.value.bitWidth <= 64 else {
+            return nil
+        }
+        return MicroCCDAmount(amount.value)
     }
 
     public var description: String {

--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -13,8 +13,8 @@ private let ten = BigUInt(10)
 public struct Amount: Equatable {
     /// The amount value given as an arbitrary sized unsigned integer, i.e. without any decimal separator.
     public var value: BigUInt
-    /// The number of trailing digits in ``value`` that belong to the fractional part of the number.
-    public var decimalCount: UInt16 // type chosen to ensure that conversion to `Int` never fails (even on 32-bit arch)
+    /// The number of digits in ``value`` that belong to the fractional/decimal part of the number, including trailing zeros.
+    public var decimalCount: UInt16 // type is chosen to ensure that conversion to `Int` never fails (even on 32-bit arch)
 
     public init(_ value: BigUInt, decimalCount: UInt16) {
         self.value = value
@@ -22,9 +22,6 @@ public struct Amount: Equatable {
     }
 
     public init(_ string: String, decimalCount: UInt16, decimalSeparator: String? = nil) throws {
-//        guard decimalCount >= 0 else {
-//            throw AmountParseError.negativeDecimalCount
-//        }
         let sep = Self.resolveDecimalSeparator(decimalSeparator)
         if let sepIdx = string.firstIndex(of: sep[sep.startIndex]) {
             let wholePart = string[string.startIndex ..< sepIdx]

--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -1,0 +1,89 @@
+import BigInt
+import Foundation
+
+public enum AmountParseError: Error {
+    case invalidInput
+    case negativeDecimals
+    case fractionPartTooLong
+    case inputTooLarge
+}
+
+private let ten = BigUInt(10)
+
+public struct Amount {
+    public var intValue: BigUInt
+
+    public var decimals: Int
+
+    public static func parse(input: String, decimals: Int, decimalSeparator: String = ".") throws -> Amount {
+        guard decimals >= 0 else {
+            throw AmountParseError.negativeDecimals
+        }
+
+        let sep = decimalSeparator[decimalSeparator.startIndex]
+        if let idx = input.firstIndex(of: sep) {
+            let wholePart = input[input.startIndex ..< idx]
+            let idx1 = input.index(idx, offsetBy: 1)
+            let fracPart = input[idx1 ..< input.endIndex]
+            guard let wholePartInt = BigUInt(wholePart), let fracPartInt = BigUInt(fracPart) else {
+                throw AmountParseError.invalidInput
+            }
+            guard fracPart.count <= decimals else {
+                throw AmountParseError.fractionPartTooLong
+            }
+            let multipliedWholeInt = wholePartInt * ten.power(decimals)
+            let multipliedFractionInt = fracPartInt * ten.power(decimals - fracPart.count)
+            return Amount(intValue: multipliedWholeInt + multipliedFractionInt, decimals: decimals)
+        }
+        guard let wholePartInt = BigUInt(input) else {
+            throw AmountParseError.invalidInput
+        }
+        return Amount(
+            intValue: wholePartInt * ten.power(decimals),
+            decimals: decimals
+        )
+    }
+
+    public func format(minDecimalDigits: Int, decimalSeparator: String = ".") -> String {
+        var v = intValue
+        var d = decimals
+        while d > minDecimalDigits, v % 10 == 0 {
+            v /= 10
+            d -= 1
+        }
+        return Self.format(value: v, subunitPrecision: d, decimalSeparator: decimalSeparator)
+    }
+
+    public static func format(value: BigUInt, subunitPrecision: Int, decimalSeparator: String) -> String {
+        if subunitPrecision == 0 {
+            return String(value)
+        }
+        let divisor = ten.power(subunitPrecision)
+        let int = String(value / divisor)
+        let frac = String(value % divisor)
+        let padding = String(repeating: "0", count: subunitPrecision - frac.count)
+        return "\(int)\(decimalSeparator)\(padding)\(frac)"
+    }
+}
+
+public struct CCD: CustomStringConvertible {
+    private static let decimals = 6
+
+    public var amount: Amount
+
+    public init(microCCD: MicroCCDAmount) {
+        amount = Amount(intValue: BigUInt(microCCD), decimals: Self.decimals)
+    }
+
+    public init(_ string: String) throws {
+        amount = try Amount.parse(input: string, decimals: Self.decimals)
+    }
+
+    public var description: String {
+        format(minDecimalDigits: 0)
+    }
+
+    public func format(minDecimalDigits: Int = 0) -> String {
+        amount.format(minDecimalDigits: minDecimalDigits)
+    }
+}

--- a/Sources/Concordium/Model/Amount.swift
+++ b/Sources/Concordium/Model/Amount.swift
@@ -38,9 +38,6 @@ public struct Amount: Equatable {
         }
         var value = wp * ten.power(Int(decimalCount))
         if let fracPart {
-//            if fracPart.isEmpty {
-//                throw AmountParseError.trailingDecimalSeparator
-//            }
             guard fracPart.count <= Int(decimalCount) else {
                 throw AmountParseError.tooManyFractionalDigits
             }

--- a/Tests/ConcordiumTests/Model/AmountTest.swift
+++ b/Tests/ConcordiumTests/Model/AmountTest.swift
@@ -9,12 +9,6 @@ final class AmountTest: XCTestCase {
         try Amount(input, decimalCount: decimalCount, decimalSeparator: ".")
     }
 
-//    func testCannotParseNegativeDecimals() throws {
-//        XCTAssertThrowsError(try amount("0", decimalCount: -1)) { err in
-//            XCTAssertEqual(err as! AmountParseError, AmountParseError.negativeDecimalCount)
-//        }
-//    }
-
     func testCannotParseEmpty() throws {
         XCTAssertThrowsError(try amount("", decimalCount: 0)) { err in
             XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
@@ -80,6 +74,25 @@ final class AmountTest: XCTestCase {
             XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
         }
         XCTAssertThrowsError(try amount(".1.1", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+    }
+
+    func testCanParseMulticharacterDecimalSeparator() throws {
+        XCTAssertEqual(try Amount("1%?@!2", decimalCount: 1, decimalSeparator: "%?@!"), Amount(BigUInt(12), decimalCount: 1))
+    }
+
+    func testMulticharacterDecimalSeparatorNeedsAllCharacters() throws {
+        XCTAssertThrowsError(try Amount("1%2", decimalCount: 1, decimalSeparator: "%?@!")) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try Amount("1%?2", decimalCount: 1, decimalSeparator: "%?@!")) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try Amount("1%?@2", decimalCount: 1, decimalSeparator: "%?@!")) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try Amount("1!2", decimalCount: 1, decimalSeparator: "%?@!")) { err in
             XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
         }
     }

--- a/Tests/ConcordiumTests/Model/AmountTest.swift
+++ b/Tests/ConcordiumTests/Model/AmountTest.swift
@@ -4,7 +4,7 @@ import Foundation
 import XCTest
 
 final class AmountTest: XCTestCase {
-    /// Helper function for conveniently using decimal separator ".".
+    /// Helper function for conveniently parsing amount using decimal separator ".".
     func amount(_ input: String, decimalCount: Int) throws -> Amount {
         try Amount(input, decimalCount: decimalCount, decimalSeparator: ".")
     }
@@ -23,6 +23,18 @@ final class AmountTest: XCTestCase {
 
     func testCannotParseNonNumeric() throws {
         XCTAssertThrowsError(try amount("x", decimalCount: 1)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+    }
+
+    func testCannotParseWhitespace() throws {
+        XCTAssertThrowsError(try amount(" 1", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try amount("1 ", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try amount("1.1 ", decimalCount: 5)) { err in
             XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
         }
     }
@@ -47,12 +59,28 @@ final class AmountTest: XCTestCase {
         XCTAssertEqual(try amount(".01", decimalCount: 2), Amount(BigUInt(1), decimalCount: 2))
     }
 
-    func testCannotParseEmptyFracPart() throws {
-        XCTAssertThrowsError(try amount("1.", decimalCount: 1)) { err in
-            XCTAssertEqual(err as! AmountParseError, AmountParseError.trailingDecimalSeparator)
+    // This syntax is not commonly accepted, but it's unambiguous so we're (somewhat arbitrarily) allowing it.
+    // It does avoid the user from being hit by validation errors while interactively entering an amount...
+    func testCanParseEmptyFracPart() throws {
+        XCTAssertEqual(try amount("1.", decimalCount: 1), Amount(BigUInt(10), decimalCount: 1))
+        XCTAssertEqual(try amount(".", decimalCount: 1), Amount(BigUInt(0), decimalCount: 1))
+    }
+
+    func testCannotParseMultipleDecimalSeparators() throws {
+        XCTAssertThrowsError(try amount("..", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
         }
-        XCTAssertThrowsError(try amount(".", decimalCount: 1)) { err in
-            XCTAssertEqual(err as! AmountParseError, AmountParseError.trailingDecimalSeparator)
+        XCTAssertThrowsError(try amount(".1.", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try amount("1..1", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try amount("1.1.", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+        XCTAssertThrowsError(try amount(".1.1", decimalCount: 5)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
         }
     }
 
@@ -98,8 +126,14 @@ final class AmountTest: XCTestCase {
     }
 
     func testCanUseOtherDecimalSeparator() throws {
-        XCTAssertEqual(try Amount("0@0", decimalCount: 1, decimalSeparator: "@"), Amount(BigUInt(0), decimalCount: 1))
-        XCTAssertEqual(try Amount("1x2", decimalCount: 1, decimalSeparator: "x"), Amount(BigUInt(12), decimalCount: 1))
+        XCTAssertEqual(
+            try Amount("0@0", decimalCount: 1, decimalSeparator: "@"),
+            Amount(BigUInt(0), decimalCount: 1)
+        )
+        XCTAssertEqual(
+            try Amount("1x2", decimalCount: 1, decimalSeparator: "x"),
+            Amount(BigUInt(12), decimalCount: 1)
+        )
     }
 
     func testCannotParseDotWhenUsingOtherDecimalSeparator() throws {
@@ -108,13 +142,97 @@ final class AmountTest: XCTestCase {
         }
     }
 
-    // TODO: Implement...
-//    func testUsesDecimalSeparatorFromLocaleByDefault() throws {
-//        var components = Locale.Components(languageCode: "da", languageRegion: "DK")
-    ////        components.region = Locale.Region("S")
-//        let da_DK = Locale(components: components)
-//        UserDefaults.standard.set("da", forKey: "i18n_language")
-//    }
+    func testWithoutTrailingZerosCanTrimAllZeroes() {
+        // No trailing zeros to trim.
+        XCTAssertEqual(
+            Amount(BigUInt(1), decimalCount: 1).withoutTrailingZeros(minDecimalCount: 0),
+            Amount(BigUInt(1), decimalCount: 1)
+        )
+        // Trailing zero is in integer part, not fractional.
+        XCTAssertEqual(
+            Amount(BigUInt(10), decimalCount: 0).withoutTrailingZeros(minDecimalCount: 0),
+            Amount(BigUInt(10), decimalCount: 0)
+        )
+        // Trim single trailing zero.
+        XCTAssertEqual(
+            Amount(BigUInt(10), decimalCount: 1).withoutTrailingZeros(minDecimalCount: 0),
+            Amount(BigUInt(1), decimalCount: 0)
+        )
+        // Trim both of two trailing zeros.
+        XCTAssertEqual(
+            Amount(BigUInt(1200), decimalCount: 2).withoutTrailingZeros(minDecimalCount: 0),
+            Amount(BigUInt(12), decimalCount: 0)
+        )
+    }
 
-    // TODO: Add tests for formatting
+    func testWithoutTrailingZerosCanTrimToMinDecimalCount() {
+        // No trailing zeros to trim.
+        XCTAssertEqual(
+            Amount(BigUInt(1), decimalCount: 1).withoutTrailingZeros(minDecimalCount: 1),
+            Amount(BigUInt(1), decimalCount: 1)
+        )
+        // Trim until there's at least 1 decimal, but there already is and it's a zero.
+        XCTAssertEqual(
+            Amount(BigUInt(10), decimalCount: 1).withoutTrailingZeros(minDecimalCount: 1),
+            Amount(BigUInt(10), decimalCount: 1)
+        )
+        // Trim 1 of 2 trailing zeros.
+        XCTAssertEqual(
+            Amount(BigUInt(10), decimalCount: 2).withoutTrailingZeros(minDecimalCount: 1),
+            Amount(BigUInt(1), decimalCount: 1)
+        )
+        // Trim until there's at least 1 decimal, but the first two are non-zero.
+        XCTAssertEqual(
+            Amount(BigUInt(1200), decimalCount: 4).withoutTrailingZeros(minDecimalCount: 1),
+            Amount(BigUInt(12), decimalCount: 2)
+        )
+        // Trim 2 of 4 trailing zeros.
+        XCTAssertEqual(
+            Amount(BigUInt(100_000), decimalCount: 4).withoutTrailingZeros(minDecimalCount: 2),
+            Amount(BigUInt(1000), decimalCount: 2)
+        )
+    }
+
+    /// Helper function for conveniently formatting amount using decimal separator ".".
+    func format(_ amount: Amount) -> String {
+        amount.format(decimalSeparator: ".")
+    }
+
+    func testFormat() {
+        XCTAssertEqual(
+            format(Amount(BigUInt(0), decimalCount: 0)),
+            "0"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(1), decimalCount: 0)),
+            "1"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(10), decimalCount: 0)),
+            "10"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(0), decimalCount: 1)),
+            "0.0"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(1), decimalCount: 1)),
+            "0.1"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(10), decimalCount: 1)),
+            "1.0"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(10), decimalCount: 2)),
+            "0.10"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(1234), decimalCount: 2)),
+            "12.34"
+        )
+    }
+
+    // TODO: Figure out how to test that decimal separator from locale is used by default
+    // (I've not been able to change `Locale.current` programmatically).
 }

--- a/Tests/ConcordiumTests/Model/AmountTest.swift
+++ b/Tests/ConcordiumTests/Model/AmountTest.swift
@@ -193,6 +193,13 @@ final class AmountTest: XCTestCase {
         )
     }
 
+    func testTrimmingToMinDecimalCountAboveDecimalCountDoesNothing() {
+        XCTAssertEqual(
+            Amount(BigUInt(100), decimalCount: 2).withoutTrailingZeros(minDecimalCount: 100),
+            Amount(BigUInt(100), decimalCount: 2)
+        )
+    }
+
     /// Helper function for conveniently formatting amount using decimal separator ".".
     func format(_ amount: Amount) -> String {
         amount.format(decimalSeparator: ".")
@@ -235,4 +242,12 @@ final class AmountTest: XCTestCase {
 
     // TODO: Figure out how to test that decimal separator from locale is used by default
     // (I've not been able to change `Locale.current` programmatically).
+
+    func testMicroCCDAmountForCCDWithinRange() throws {
+        XCTAssertEqual(MicroCCDAmount(123_456_789), try CCD("123.456789", decimalSeparator: ".").microCCDAmount)
+    }
+
+    func testMicroCCDAmountForCCDOutsideRange() throws {
+        XCTAssertNil(try CCD("123456789012347890").microCCDAmount)
+    }
 }

--- a/Tests/ConcordiumTests/Model/AmountTest.swift
+++ b/Tests/ConcordiumTests/Model/AmountTest.swift
@@ -1,0 +1,120 @@
+import BigInt
+@testable import Concordium
+import Foundation
+import XCTest
+
+final class AmountTest: XCTestCase {
+    /// Helper function for conveniently using decimal separator ".".
+    func amount(_ input: String, decimalCount: Int) throws -> Amount {
+        try Amount(input, decimalCount: decimalCount, decimalSeparator: ".")
+    }
+
+    func testCannotParseNegativeDecimals() throws {
+        XCTAssertThrowsError(try amount("0", decimalCount: -1)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.negativeDecimalCount)
+        }
+    }
+
+    func testCannotParseEmpty() throws {
+        XCTAssertThrowsError(try amount("", decimalCount: 0)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+    }
+
+    func testCannotParseNonNumeric() throws {
+        XCTAssertThrowsError(try amount("x", decimalCount: 1)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+    }
+
+    func testCanParseNoDecimals() throws {
+        XCTAssertEqual(try amount("0", decimalCount: 0), Amount(BigUInt(0), decimalCount: 0))
+        XCTAssertEqual(try amount("00", decimalCount: 0), Amount(BigUInt(0), decimalCount: 0))
+        XCTAssertEqual(try amount("12", decimalCount: 0), Amount(BigUInt(12), decimalCount: 0))
+    }
+
+    func testCanParseDecimalCountDecimals() throws {
+        XCTAssertEqual(try amount("0.0", decimalCount: 1), Amount(BigUInt(0), decimalCount: 1))
+        XCTAssertEqual(try amount("00.1", decimalCount: 1), Amount(BigUInt(1), decimalCount: 1))
+        XCTAssertEqual(try amount("1.0", decimalCount: 1), Amount(BigUInt(10), decimalCount: 1))
+        XCTAssertEqual(try amount("0.02", decimalCount: 2), Amount(BigUInt(2), decimalCount: 2))
+        XCTAssertEqual(try amount("0.12", decimalCount: 2), Amount(BigUInt(12), decimalCount: 2))
+        XCTAssertEqual(try amount("1.20", decimalCount: 2), Amount(BigUInt(120), decimalCount: 2))
+    }
+
+    func testCanParseEmptyWholePart() throws {
+        XCTAssertEqual(try amount(".1", decimalCount: 1), Amount(BigUInt(1), decimalCount: 1))
+        XCTAssertEqual(try amount(".01", decimalCount: 2), Amount(BigUInt(1), decimalCount: 2))
+    }
+
+    func testCannotParseEmptyFracPart() throws {
+        XCTAssertThrowsError(try amount("1.", decimalCount: 1)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.trailingDecimalSeparator)
+        }
+        XCTAssertThrowsError(try amount(".", decimalCount: 1)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.trailingDecimalSeparator)
+        }
+    }
+
+    func testCanParseFewerDecimalsThanDecimalCount() throws {
+        XCTAssertEqual(try amount("1", decimalCount: 1), Amount(BigUInt(10), decimalCount: 1))
+        XCTAssertEqual(try amount("0.1", decimalCount: 2), Amount(BigUInt(10), decimalCount: 2))
+        XCTAssertEqual(try amount("0.10", decimalCount: 3), Amount(BigUInt(100), decimalCount: 3))
+    }
+
+    func testCannotParseMoreDecimalsThanDecimalCount() throws {
+        XCTAssertThrowsError(try amount("0.0", decimalCount: 0)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.tooManyFractionalDigits)
+        }
+        XCTAssertThrowsError(try amount("1.23", decimalCount: 1)) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.tooManyFractionalDigits)
+        }
+    }
+
+    func testCanParseManyZeros() throws {
+        XCTAssertEqual(
+            try amount("0000000000000000000000000000000000000000", decimalCount: 0),
+            Amount(BigUInt(0), decimalCount: 0)
+        )
+        XCTAssertEqual(
+            try amount("00000000000000000000.00000000000000000000", decimalCount: 20),
+            Amount(BigUInt(0), decimalCount: 20)
+        )
+    }
+
+    func testCanParseHugeNumber() throws {
+        XCTAssertEqual(
+            try amount("0123456789123456789001234567891234567890", decimalCount: 0),
+            Amount(BigUInt("123456789123456789001234567891234567890"), decimalCount: 0)
+        )
+        XCTAssertEqual(
+            try amount("012345678901234567890.0123456789123456789", decimalCount: 20),
+            Amount(BigUInt("1234567890123456789001234567891234567890"), decimalCount: 20)
+        )
+        XCTAssertEqual(
+            try amount("012345678901234567890012345678901234567890", decimalCount: 20),
+            Amount(BigUInt("1234567890123456789001234567890123456789000000000000000000000"), decimalCount: 20)
+        )
+    }
+
+    func testCanUseOtherDecimalSeparator() throws {
+        XCTAssertEqual(try Amount("0@0", decimalCount: 1, decimalSeparator: "@"), Amount(BigUInt(0), decimalCount: 1))
+        XCTAssertEqual(try Amount("1x2", decimalCount: 1, decimalSeparator: "x"), Amount(BigUInt(12), decimalCount: 1))
+    }
+
+    func testCannotParseDotWhenUsingOtherDecimalSeparator() throws {
+        XCTAssertThrowsError(try Amount("2.1", decimalCount: 1, decimalSeparator: "!")) { err in
+            XCTAssertEqual(err as! AmountParseError, AmountParseError.invalidInput)
+        }
+    }
+
+    // TODO: Implement...
+//    func testUsesDecimalSeparatorFromLocaleByDefault() throws {
+//        var components = Locale.Components(languageCode: "da", languageRegion: "DK")
+    ////        components.region = Locale.Region("S")
+//        let da_DK = Locale(components: components)
+//        UserDefaults.standard.set("da", forKey: "i18n_language")
+//    }
+
+    // TODO: Add tests for formatting
+}

--- a/Tests/ConcordiumTests/Model/AmountTest.swift
+++ b/Tests/ConcordiumTests/Model/AmountTest.swift
@@ -54,7 +54,8 @@ final class AmountTest: XCTestCase {
     }
 
     // This syntax is not commonly accepted, but it's unambiguous so we're (somewhat arbitrarily) allowing it.
-    // It does avoid the user from being hit by validation errors while interactively entering an amount...
+    // It avoids the user from being hit by validation errors while interactively entering an amount, which is probably sane.
+    // If the application wishes to disallow this kind of syntax, it can check the input against the result converted back into a string using `format`.
     func testCanParseEmptyFracPart() throws {
         XCTAssertEqual(try amount("1.", decimalCount: 1), Amount(BigUInt(10), decimalCount: 1))
         XCTAssertEqual(try amount(".", decimalCount: 1), Amount(BigUInt(0), decimalCount: 1))

--- a/Tests/ConcordiumTests/Model/AmountTest.swift
+++ b/Tests/ConcordiumTests/Model/AmountTest.swift
@@ -5,15 +5,15 @@ import XCTest
 
 final class AmountTest: XCTestCase {
     /// Helper function for conveniently parsing amount using decimal separator ".".
-    func amount(_ input: String, decimalCount: Int) throws -> Amount {
+    func amount(_ input: String, decimalCount: UInt16) throws -> Amount {
         try Amount(input, decimalCount: decimalCount, decimalSeparator: ".")
     }
 
-    func testCannotParseNegativeDecimals() throws {
-        XCTAssertThrowsError(try amount("0", decimalCount: -1)) { err in
-            XCTAssertEqual(err as! AmountParseError, AmountParseError.negativeDecimalCount)
-        }
-    }
+//    func testCannotParseNegativeDecimals() throws {
+//        XCTAssertThrowsError(try amount("0", decimalCount: -1)) { err in
+//            XCTAssertEqual(err as! AmountParseError, AmountParseError.negativeDecimalCount)
+//        }
+//    }
 
     func testCannotParseEmpty() throws {
         XCTAssertThrowsError(try amount("", decimalCount: 0)) { err in
@@ -209,6 +209,10 @@ final class AmountTest: XCTestCase {
         XCTAssertEqual(
             format(Amount(BigUInt(0), decimalCount: 0)),
             "0"
+        )
+        XCTAssertEqual(
+            format(Amount(BigUInt(0), decimalCount: 2)),
+            "0.00"
         )
         XCTAssertEqual(
             format(Amount(BigUInt(1), decimalCount: 0)),


### PR DESCRIPTION
The type (struct) is currently used for CCD, where supporting arbitrary size numbers isn't strictly necessary. But this representation ensures that numbers that are too large are handled gracefully (i.e. inputting them doesn't fail). And it's convenient when formatting that you can just change the number of decimals (see method `withoutTrailingZeros`) to remove optional number of trailing zeros.

The data type is also going to be directly useful for (fungible) CIS-2 tokens where the amounts have varying number of decimals - and also might not fit into 64 bits.