### PR TITLE
Legacy Wallet export: Unify the way data is passed to CommonCrypto

### DIFF
--- a/Sources/Concordium/LegacyWalletExport.swift
+++ b/Sources/Concordium/LegacyWalletExport.swift
@@ -116,22 +116,29 @@ func decryptLegacyWalletExport(cipher: Data, salt: Data, iterations: Int, iv: Da
 }
 
 func deriveKeyAES256(password: Data, salt: Data, rounds: Int) throws -> Data {
-    var res = [UInt8](repeating: 0, count: kCCKeySizeAES256)
-    let status = CCKeyDerivationPBKDF(
-        CCPBKDFAlgorithm(kCCPBKDF2),
-        [UInt8](password),
-        password.count,
-        [UInt8](salt),
-        salt.count,
-        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
-        UInt32(rounds),
-        &res,
-        kCCKeySizeAES256
-    )
+    var res = Data(repeating: 0, count: kCCKeySizeAES256)
+    let status =
+        password.withUnsafeBytes { passwordBytes in
+            salt.withUnsafeBytes { saltBytes in
+                res.withUnsafeMutableBytes { resBytes in
+                    CCKeyDerivationPBKDF(
+                        CCPBKDFAlgorithm(kCCPBKDF2),
+                        passwordBytes.baseAddress,
+                        passwordBytes.count,
+                        saltBytes.baseAddress,
+                        saltBytes.count,
+                        CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                        UInt32(rounds),
+                        resBytes.baseAddress,
+                        kCCKeySizeAES256
+                    )
+                }
+            }
+        }
     guard status == 0 else {
         throw DecryptExportError.keyDerivationFailed(status: status)
     }
-    return Data(bytes: res, count: res.count)
+    return res
 }
 
 func decryptAES256(key: Data, iv: Data, _ input: Data) throws -> Data {
@@ -140,26 +147,34 @@ func decryptAES256(key: Data, iv: Data, _ input: Data) throws -> Data {
         throw DecryptExportError.unsupportedKeyLength
     }
     guard iv.count == kCCBlockSizeAES128 else {
-        // Never happens as we just derived the key as AES256.
         throw DecryptExportError.unsupportedInputVectorLength
     }
-    var res = [UInt8](repeating: 0, count: input.count)
+    var res = Data(repeating: 0, count: input.count)
     var count = 0
-    let status = CCCrypt(
-        CCOperation(kCCDecrypt),
-        CCAlgorithm(kCCAlgorithmAES),
-        CCOptions(kCCOptionPKCS7Padding),
-        [UInt8](key),
-        key.count,
-        [UInt8](iv),
-        [UInt8](input),
-        input.count,
-        &res,
-        res.count,
-        &count
-    )
+    let status =
+        key.withUnsafeBytes { keyBytes in
+            iv.withUnsafeBytes { ivBytes in
+                input.withUnsafeBytes { inputBytes in
+                    res.withUnsafeMutableBytes { resBytes in
+                        CCCrypt(
+                            CCOperation(kCCDecrypt),
+                            CCAlgorithm(kCCAlgorithmAES),
+                            CCOptions(kCCOptionPKCS7Padding),
+                            keyBytes.baseAddress,
+                            keyBytes.count,
+                            ivBytes.baseAddress,
+                            inputBytes.baseAddress,
+                            inputBytes.count,
+                            resBytes.baseAddress,
+                            resBytes.count,
+                            &count
+                        )
+                    }
+                }
+            }
+        }
     guard status == kCCSuccess else {
         throw DecryptExportError.decryptionFailed(status: status)
     }
-    return Data(bytes: res, count: count)
+    return res.prefix(count)
 }

--- a/Sources/Concordium/WalletAccount.swift
+++ b/Sources/Concordium/WalletAccount.swift
@@ -12,32 +12,6 @@ public class Account {
     }
 }
 
-public protocol AccountRepository {
-    func lookup(_ address: AccountAddress) throws -> Account?
-    func insert(_ account: Account) throws
-    func remove(_ address: AccountAddress) throws
-}
-
-public class AccountStore: AccountRepository {
-    private var dictionary: [AccountAddress: Account] = [:]
-
-    public init(_ accounts: [Account] = []) {
-        accounts.forEach(insert)
-    }
-
-    public func lookup(_ address: AccountAddress) -> Account? {
-        dictionary[address]
-    }
-
-    public func insert(_ account: Account) {
-        dictionary[account.address] = account
-    }
-
-    public func remove(_ address: AccountAddress) {
-        dictionary[address] = nil
-    }
-}
-
 public protocol Signer {
     var count: Int { get }
     func sign(message: Data) throws -> Signatures

--- a/examples/CLI/Sources/ConcordiumExampleClient/commands.swift
+++ b/examples/CLI/Sources/ConcordiumExampleClient/commands.swift
@@ -202,7 +202,7 @@ struct Root: AsyncParsableCommand {
 
                 print("Fetching crypto parameters (for commitment key).")
                 let hash = try await withGRPCClient(target: rootCmd.opts.target) { client in
-                    let cryptoParams = try await client.cryptographicParameters(block: BlockIdentifier.lastFinal)
+                    let cryptoParams = try await client.cryptographicParameters(block: .lastFinal)
                     print("Deriving account address and keys.")
                     let account = try SeedBasedAccountDerivation(
                         seed: WalletSeed(seedHex: seedHex, network: walletCmd.network.network),
@@ -490,7 +490,7 @@ struct Root: AsyncParsableCommand {
                 }
                 let export = try decryptLegacyWalletExport(export: encryptedExport, password: password)
                 print("Looking up account with address '\(walletCmd.account.base58Check)' in export.")
-                guard let sender = try AccountStore(export.toSDKType()).lookup(walletCmd.account) else {
+                guard let sender = try export.toSDKType().first(where: { $0.address == walletCmd.account }) else {
                     print("Account \(walletCmd.account) not found in export.")
                     return
                 }


### PR DESCRIPTION
Pass bytes directly to CommonCrypto without copying using `withUnsafe[Mutable]Bytes`.

Also removed `AccountRepository` abstraction as it isn't necessary for what it was used for (storing the accounts of a legacy wallet export). It's also unclear whether it belongs in the SDK at all.