### PR TITLE
Prepare for initial release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,55 @@
+name: Publish release for SwiftPM package tag
+
+on:
+  push:
+    tags: '*.*.*'
+  workflow_dispatch: # trigger manually (for debugging)
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Parse ref
+      uses: bisgardo/github-action-parse-ref@v1
+      id: ref
+      with:
+        ref: '${{github.ref}}'
+    - name: 'Print outputs (for debugging)'
+      run: |
+        echo "github.ref='${{github.ref}}'"
+        echo "steps.ref.outputs.ref='${{steps.ref.outputs.ref}}'"
+        echo "steps.ref.outputs.ref-name='${{steps.ref.outputs.ref-name}}'"
+    - name: Checkout project
+      uses: actions/checkout@v4
+      with:
+        ref: '${{steps.ref.outputs.ref}}'
+    - name: Extract tag message
+      uses: bisgardo/github-action-echo@v1
+      id: tag-msg
+      with:
+        msg: '$(git for-each-ref "${{steps.ref.outputs.ref}}" --format="%(contents)")'
+        version: '${{steps.ref.outputs.ref-name}}'
+    - name: Fail if tag is not "annotated" or its message is empty
+      if: "steps.tag-msg.outputs.msg == ''"
+      run: exit 1
+    - name: Extract changelog entries
+      uses: concordium/github-action-changelog-extract@v1
+      id: changelog
+      with:
+        file: 'CHANGELOG.md'
+        version: '${{steps.tag-msg.outputs.version}}'
+    - name: Upload package as GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: '${{steps.tag-msg.outputs.version}}'
+        # Release body is the message of the annotated tag followed by the changelog entries for the version.
+        body: |
+          ${{steps.tag-msg.outputs.msg}}
+          
+          # Changelog
+          
+          ${{steps.changelog.outputs.section}}
+        files: '${{steps.release.outputs.npm-pack-file}}'
+        name: '${{steps.release.outputs.github-release-name}}'
+        generate_release_notes: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Upload package as GitHub release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: '${{steps.tag-msg.outputs.version}}'
+        name: '${{steps.tag-msg.outputs.version}}'
         # Release body is the message of the annotated tag followed by the changelog entries for the version.
         body: |
           ${{steps.tag-msg.outputs.msg}}
@@ -50,6 +50,3 @@ jobs:
           # Changelog
           
           ${{steps.changelog.outputs.section}}
-        files: '${{steps.release.outputs.npm-pack-file}}'
-        name: '${{steps.release.outputs.github-release-name}}'
-        generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2024-04-26
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Concordium Swift SDK
 
-**STATUS: EARLY DEVELOPMENT**
-
 An SDK for applications written in the [Swift Programming Language](https://www.swift.org/) to
 interact with the [Concordium Blockchain](https://concordium.com).
 
@@ -22,18 +20,15 @@ Once this SDK is ready for production, it will completely replace this old libra
 
 ## Usage
 
-*No tags have been added to "publish" a build yet. The following is not going to work until v1.0 has been published.
-To use it in the current, unfinished state, replace `"1.0"` with `"main"`.*
-
 The SDK is available as a [SwiftPM package](https://developer.apple.com/documentation/xcode/swift-packages)
 hosted on GitHub as this repository.
 To include it as a dependency, add the following 
 
 ```swift
-.package(url: "https://github.com/Concordium/concordium-swift-sdk.git", from: "1.0")
+.package(url: "https://github.com/Concordium/concordium-swift-sdk.git", from: "<version>")
 ```
 
-and adding
+where `<version>` is replaced by an actual version (see tags/releases on GitHub). Then add
 
 ```swift
 .product(name: "Concordium", package: "concordium-swift-sdk")
@@ -52,6 +47,11 @@ The repository includes some example projects that show how to integrate the SDK
   It's also used to exercise the gRPC client in ways that are hard to cover with unit tests.
 
 An example wallet app is currently in development.
+
+## Documentation
+
+See the [developer documentation site](https://developer.concordium.software/en/mainnet/net/guides/wallet-sdk/wallet-sdk.html)
+for collected documentation of the various Wallet SDKs.
 
 ## Development
 
@@ -88,7 +88,7 @@ The CI workflow [`Build and test`](https://github.com/Concordium/concordium-swif
 checks that the code base is correctly formatted before PRs are merged.
 
 The formatter has been integrated as a
-[Swift Package Manger plugin](https://github.com/nicklockwood/SwiftFormat#swift-package-manager-plugin).
+[Swift Package Manager plugin](https://github.com/nicklockwood/SwiftFormat#swift-package-manager-plugin).
 It's possible to run the tool in a variety of ways (see the previous link for all options).
 The easiest option is to run it on the command line via
 


### PR DESCRIPTION
Removed the "early development" status from readme and initialize a changelog.

Added workflow for publishing a release automatically when an annotated tag is pushed. The release uses the message of the tag and the appropriate changelog section in the release notes.