### PR TITLE
Change submodule to absolute path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "concordium-grpc-api"]
 	path = concordium-grpc-api
-	url = ../concordium-grpc-api.git
+	url = https://github.com/Concordium/concordium-grpc-api.git


### PR DESCRIPTION
Relative submodule paths do not work with swiftPM apparently... This fixes that 😄 
