### PR TITLE
Fix MicroCcdAmount type alias reference in Account domain model

### DIFF
--- a/Sources/Concordium/Domain/Account.swift
+++ b/Sources/Concordium/Domain/Account.swift
@@ -95,7 +95,7 @@ public typealias SignatureThreshold = UInt8
 public typealias RevocationThreshold = UInt8
 
 /// Amount of uCCD.
-public typealias MicroCCDAmount = ConcordiumWalletCrypto.MicroCCDAmount
+public typealias MicroCCDAmount = ConcordiumWalletCrypto.MicroCcdAmount
 
 public typealias EncryptedAmount = Data
 


### PR DESCRIPTION
## Purpose

This PR fixes a type alias reference in the account domain model by updating the uCCD amount alias to the correct wallet-crypto type name.

## Changes

Updated the alias :
From: ConcordiumWalletCrypto.MicroCCDAmount
To: ConcordiumWalletCrypto.MicroCcdAmount

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.